### PR TITLE
Fixed Radio Buttons in Bar Modes

### DIFF
--- a/views/pages/controlpanel.ejs
+++ b/views/pages/controlpanel.ejs
@@ -71,14 +71,22 @@
                 <button type="button" onclick="doStep(<%-currentStep%>)">Next Step</button>
             </form>
         <form>
-            <input type="radio" name="mode" id="modeP" onchange="modeChange()" value="poll">
-            <label class="form-control" for="modeP">Poll Mode</label>
-            <input type="radio" name="mode" id="modeL" onchange="modeChange()" value="lesson">
-            <label class="form-control" for="modeL">Lesson Mode</label>
-            <input type="radio" name="mode" id="modeQ" onchange="modeChange()" value="quiz">
-            <label class="form-control" for="modeQ">Quiz Mode</label>
-            <input type="radio" name="mode" id="modePT" onchange="modeChange()" value="playtime">
-            <label class="form-control" for="modePT">Playtime Mode</label>
+            <label class="form-control" id="pollControl" for="modeP">
+                <input type="radio" name="mode" id="modeP" onchange="modeChange()" value="poll">
+                Poll Mode
+            </label>
+            <label class="form-control" id="pollControl" for="modeL">
+                <input type="radio" name="mode" id="modeL" onchange="modeChange()" value="lesson">
+                Lesson Mode
+            </label>
+            <label class="form-control" id="pollControl" for="modeQ">
+                <input type="radio" name="mode" id="modeQ" onchange="modeChange()" value="quiz">
+                Quiz Mode
+            </label>
+            <label class="form-control" id="pollControl" for="modePT">
+                <input type="radio" name="mode" id="modePT" onchange="modeChange()" value="playtime">
+                Playtime Mode
+            </label>
         </form>
         </div>
     </body>


### PR DESCRIPTION
Fixed issue with radio buttons when selecting bar modes, in which the radio buttons and labels would be attached to left side of screen; now they sit in center.

#156 