### PR TITLE
Fix students not saving in classes

### DIFF
--- a/modules/class.js
+++ b/modules/class.js
@@ -210,13 +210,13 @@ async function getClassStudents(classId) {
 	    const userData = studentsData[username];
 	    students[username] = new Student(
 	        username,
-	        userData.email,
 	        userData.id,
 	        userData.permissions,
 	        userData.API,
+			JSON.parse(userData.ownedPolls),
+			JSON.parse(userData.sharedPolls),
 	        userData.tags,
-	        displayName = userData.displayName || "NPOM",
-	        userData.verified,
+	        displayName = userData.displayName,
 			false
 	    );
 	};

--- a/routes/login.js
+++ b/routes/login.js
@@ -124,7 +124,6 @@ module.exports = {
                                     JSON.parse(userData.sharedPolls),
                                     userData.tags,
                                     userData.displayName,
-                                    userData.verified,
                                     false
                                 )
 
@@ -290,7 +289,6 @@ module.exports = {
 
                     classInformation.users[userData.username] = new Student(
                         username, // Username
-                        null, // Email
                         userData.id, // Id
                         GUEST_PERMISSIONS,
                         null, // API key


### PR DESCRIPTION
The student class was being passed the incorrect number of parameters, which caused weird issues such as students being considered guests which would cause their classes to not save.