### PR TITLE
Fix remove being displayed as a poll option and major exploit

### DIFF
--- a/sockets/pollResponse.js
+++ b/sockets/pollResponse.js
@@ -6,8 +6,13 @@ const { advancedEmitToClass } = require("../modules/socketUpdates")
 module.exports = {
     run(socket, socketUpdates) {
         // /poll websockets for updating the database
-        socket.on('pollResp', (res, textRes, resWeight, resLength) => {
+        socket.on('pollResp', (res, textRes) => {
             try {
+                // This is hardcoded for now as digipogs aren't implemented yet.
+                // These should be calculated on the server rather than the client to prevent exploits to obtain digipogs.
+                const resWeight = 1;
+                const resLength = 0;
+
                 logger.log('info', `[pollResp] ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`)
                 logger.log('info', `[pollResp] res=(${res}) textRes=(${textRes}) resWeight=(${resWeight}) resLength=(${resLength})`)
                 

--- a/sockets/pollResponse.js
+++ b/sockets/pollResponse.js
@@ -27,8 +27,8 @@ module.exports = {
                     }
                 }
 
-                classroom.students[username].pollRes.buttonRes = res
-                classroom.students[username].pollRes.textRes = textRes
+                classroom.students[username].pollRes.buttonRes = res == "remove" ? "" : res
+                classroom.students[username].pollRes.textRes = res == "remove" ? "" : textRes
                 classroom.students[username].pollRes.time = new Date()
 
                 for (let i = 0; i < resLength; i++) {


### PR DESCRIPTION
- The remove button is no longer shown as a response on the teacher panel
- Students can no longer pass a parameter on the /pollResp socket event that would give the user digipogs and crash the server if the number provided is too large.