### PR TITLE
Fix manager panel manual verification

### DIFF
--- a/modules/manager.js
+++ b/modules/manager.js
@@ -1,4 +1,5 @@
-const { database } = require("./database");
+const { database, dbGetAll} = require("./database");
+const jwt = require('jsonwebtoken');
 
 async function getManagerData() {
     const [users, classrooms] = await Promise.all([
@@ -21,6 +22,25 @@ async function getManagerData() {
             })
         })
     ]);
+
+    // Grab the unverified users from the database and insert them into the user data
+    const tempUsers = await dbGetAll('SELECT * FROM temp_user_creation_data');
+    for (const tempUser of tempUsers) {
+        // Grab the token, decode it, and check if they're already accounted for in the users table
+        const token = tempUser.token;
+        const decodedData = jwt.decode(token);
+        if (users[decodedData.email]) {
+            continue;
+        }
+
+        users[decodedData.newSecret] = {
+            id: decodedData.newSecret,
+            email: decodedData.email,
+            permissions: decodedData.permissions,
+            displayName: decodedData.displayName,
+            verified: false
+        }
+    }
 
     return { users, classrooms };
 }

--- a/routes/login.js
+++ b/routes/login.js
@@ -399,6 +399,7 @@ module.exports = {
                             accountCreationData.newSecret = newSecret;
                             accountCreationData.hashedPassword = hashedPassword;
                             accountCreationData.permissions = permissions;
+                            accountCreationData.password = undefined;
 
                             // Create JWT token with this information then store it in the temp_user_creation_data in the database
                             // This will be used to finish creating the account once the email is verified

--- a/sockets/managerPanel.js
+++ b/sockets/managerPanel.js
@@ -1,9 +1,10 @@
 const { classInformation } = require("../modules/class/classroom")
-const { database } = require("../modules/database")
+const { database, dbRun, dbGetAll } = require("../modules/database")
 const { logger } = require("../modules/logger")
 const { TEACHER_PERMISSIONS } = require("../modules/permissions")
 const { getUserClass } = require("../modules/user")
 const { io } = require("../modules/webServer")
+const jwt = require("jsonwebtoken");
 
 module.exports = {
     run(socket, socketUpdates) {
@@ -32,29 +33,28 @@ module.exports = {
         })
 
         // For managers to swap a user's verified status
+        // Unlike for verified users, unverified users will have their secret for the ID
         socket.on("verifyChange", async (id) => {
             try {
                 logger.log('info', `[verifyUser] ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`)
                 logger.log('info', `[verifyUser] user=(${id})`)
 
-                // Get user from database
-                const user = await new Promise((resolve, reject) => {
-                    database.get('SELECT * FROM users WHERE id=?', id, (err, user) => {
-                        if (err) reject(err)
-                        resolve(user)
-                    })
-                })
+                // Get the user from the temp users table
+                const tempUsers = await dbGetAll('SELECT * FROM temp_user_creation_data');
+                let tempUser;
+                for (const user of tempUsers) {
+                    const userData = jwt.decode(user.token);
+                    if (userData.newSecret == id) {
+                        tempUser = userData;
+                        break;
+                    }
+                }
 
-                if (!user) logger.log('warning', `[verifyUser] Could not find user (${id}) in classInformation.users`)
-                
-                // Toggle verified status
-                user.verified ? user.verified = 0 : user.verified = 1
-                database.run('UPDATE users SET verified=? WHERE id=?', [user.verified, id], (err) => {
-                    if (err) logger.log('error', err.stack);
-                });
-
-                // Notify the user to reload
-                io.to(`user-${user.email}`).emit('reload')
+                // If a temp user wasn't found, exit
+                // Otherwise, insert their data into the users table, and delete them from the temp user table.
+                if (!tempUser) return;
+                await dbRun('INSERT INTO users (email, password, permissions, API, secret, displayName, verified) VALUES (?, ?, ?, ?, ?, ?, ?)', [tempUser.email, tempUser.hashedPassword, tempUser.permissions, tempUser.newAPI, tempUser.newSecret, tempUser.displayName, 1]);
+                await dbRun('DELETE FROM temp_user_creation_data WHERE secret=?', [tempUser.newSecret]);
             } catch (err) {
                 logger.log('error', err.stack);
             }


### PR DESCRIPTION
Fixes for #699:
- Added temporary users to users data returned by /api/manager
- Fixed verifyChange socket to properly verify users by moving them from the temp user table to the actual user table
- Removed unhashed password from data stored in the temporary user's tokens