### PR TITLE
Fix guest issues and refresh pin error

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,8 +18,7 @@ const { initSocketRoutes } = require('./sockets/init.js')
 const { app, io, http, getIpAccess } = require('./modules/webServer.js')
 const { settings } = require('./modules/config.js');
 const { lastActivities, INACTIVITY_LIMIT } = require("./sockets/middleware/inactivity");
-const { userSocketUpdates } = require("./sockets/init");
-const { userSockets } = require("./modules/socketUpdates");
+const { logout } = require("./modules/user/userSession");
 const authentication = require('./routes/middleware/authentication.js')
 
 // Set EJS as our view engine
@@ -63,11 +62,8 @@ setInterval(() => {
         const userSockets = lastActivities[email];
         for (const [socketId, activity] of Object.entries(userSockets)) {
             if (currentTime - activity.time > INACTIVITY_LIMIT) {
-                const socketUpdates = userSocketUpdates[email];
-                if (socketUpdates) {
-                    socketUpdates.logout(activity.socket); // Log the user out
-                    delete lastActivities[email]; // Remove the user from the inactivity check
-                }
+                logout(activity.socket); // Log the user out
+                delete lastActivities[email]; // Remove the user from the inactivity check
             }
         }
     }

--- a/modules/class/class.js
+++ b/modules/class/class.js
@@ -247,7 +247,7 @@ async function deleteRooms(userId) {
         await dbRun('DELETE FROM classroom WHERE owner=?', classrooms[0].owner)
         for (const classroom of classrooms) {
             if (classInformation.classrooms[classroom.id]) {
-                this.endClass(classroom.id)
+                await endClass(classroom.id)
             }
 
             await Promise.all([

--- a/modules/permissions.js
+++ b/modules/permissions.js
@@ -61,6 +61,7 @@ const GLOBAL_SOCKET_PERMISSIONS = {
 	joinRoom: GUEST_PERMISSIONS,
 	getActiveClass: GUEST_PERMISSIONS,
 	refreshApiKey: STUDENT_PERMISSIONS,
+    refreshPin: STUDENT_PERMISSIONS,
 	transferDigipogs: STUDENT_PERMISSIONS,
 	transferDigipogsResult: STUDENT_PERMISSIONS,
 	awardDigipogs: TEACHER_PERMISSIONS,

--- a/modules/permissions.js
+++ b/modules/permissions.js
@@ -16,7 +16,8 @@ const PAGE_PERMISSIONS = {
 	selectclass: { permissions: GUEST_PERMISSIONS, classPage: false },
 	managerpanel: { permissions: MANAGER_PERMISSIONS, classPage: false },
 	downloaddatabase: { permissions: MANAGER_PERMISSIONS, classPage: false },
-	logs: { permissions: MANAGER_PERMISSIONS, classPage: false }
+	logs: { permissions: MANAGER_PERMISSIONS, classPage: false },
+	profile: { permissions: STUDENT_PERMISSIONS, classPage: false }
 }
 
 const CLASS_PERMISSIONS = {

--- a/modules/user/user.js
+++ b/modules/user/user.js
@@ -1,10 +1,6 @@
 const { classInformation } = require('../class/classroom')
-const { database, dbGetAll, dbGet, dbRun } = require('../database')
+const { database, dbGetAll, dbGet } = require('../database')
 const { logger } = require('../logger')
-const { userSockets, managerUpdate } = require("../socketUpdates");
-const { userSocketUpdates } = require("../../sockets/init");
-const { deleteRooms } = require("../class/class");
-const { deleteCustomPolls } = require("../polls");
 
 /**
  * Asynchronous function to get the current user's data.
@@ -122,145 +118,6 @@ async function getUser(api) {
     }
 }
 
-function logout(socket) {
-    const email = socket.request.session.email
-    const userId = socket.request.session.userId
-    const classId = socket.request.session.classId
-
-    // Remove this socket from the user's active sockets first and determine if this was the last one
-    let isLastSession = false;
-    if (userSockets[email]) {
-        delete userSockets[email][socket.id];
-        if (Object.keys(userSockets[email]).length === 0) {
-            delete userSockets[email];
-            isLastSession = true;
-        }
-    } else {
-        isLastSession = true;
-    }
-
-    // Leave the room only on this socket
-    if (classId) socket.leave(`class-${classId}`)
-
-    socket.request.session.destroy((err) => {
-        try {
-            if (err) throw err
-
-            // Reload just this client
-            socket.emit('reload')
-
-            // If the socket had an associated last activity, remove it
-            if (lastActivities[email] && lastActivities[email][socket.id]) {
-                delete lastActivities[email][socket.id];
-            }
-
-            // Only clear global user/class state if this was the last active session
-            if (isLastSession) {
-                const user = classInformation.users[email];
-                if (user) {
-                    user.activeClass = null;
-                    user.classPermissions = null;
-                }
-
-                // If the user was not in a class, then return
-                if (!classId) return;
-
-                // If the class is loaded, then mark the user as offline
-                const classroom = classInformation.classrooms[classId];
-                if (classroom) {
-                    const student = classroom.students[email];
-                    if (student) {
-                        if (student.isGuest) {
-                            delete classroom.students[email];
-                        } else {
-                            student.activeClass = null;
-                            student.tags = student.tags ? student.tags + ',Offline' : 'Offline';
-                        }
-                    }
-
-                    // Update class permissions and virtual bar
-                    this.classUpdate(classId);
-                }
-
-                // If this user owns the classroom, end it
-                database.get(
-                    'SELECT * FROM classroom WHERE owner=? AND id=?',
-                    [userId, classId],
-                    (err, classroom) => {
-                        if (err) {
-                            logger.log('error', err.stack)
-                        }
-
-                        if (classroom) {
-                            endClass(classroom.id);
-                        }
-                    }
-                )
-            }
-        } catch (err) {
-            logger.log('error', err.stack)
-        }
-    })
-}
-
-async function deleteUser(userId, userSession) {
-    try {
-        logger.log('info', `[deleteUser] session=(${JSON.stringify(userSession)})`)
-        logger.log('info', `[deleteUser] userId=(${userId})`)
-
-        // Get the user's email from their ID and verify they exist
-        const user = await dbGet('SELECT * FROM users WHERE id=?', [userId]);
-        if (!user) {
-            return 'User not found'
-        }
-
-        // Log the user out if they're currently online
-        const userSocketsMap = userSockets[user.email];
-        const usersSocketUpdates = userSocketUpdates[user.email];
-        if (userSocketsMap && usersSocketUpdates) {
-            const anySocket = Object.values(userSocketsMap)[0];
-            if (anySocket) {
-                usersSocketUpdates.logout(anySocket);
-            }
-        }
-
-        try {
-            await dbRun('BEGIN TRANSACTION')
-            await Promise.all([
-                dbRun('DELETE FROM users WHERE id=?', userId),
-                dbRun('DELETE FROM classusers WHERE studentId=?', userId),
-                dbRun('DELETE FROM shared_polls WHERE userId=?', userId),
-            ])
-
-            // await userSocketUpdates.deleteCustomPolls(userId)
-            await deleteCustomPolls(userId)
-            await deleteRooms(userId) // Delete any rooms owned by the user
-
-            // If the student is online, remove them from any class they're in and update the control panel
-            const student = classInformation.users[user.email];
-            if (student) {
-                const activeClass = classInformation.users[user.email].activeClass;
-                const classroom = classInformation.classrooms[activeClass];
-                delete classInformation.users[user.email];
-                if (classroom) {
-                    delete classroom.students[user.email];
-                    userSocketUpdates.classUpdate();
-                }
-            }
-
-            await dbRun('COMMIT')
-            await managerUpdate()
-            return true
-        } catch (err) {
-            await dbRun('ROLLBACK')
-            throw err
-        }
-    } catch (err) {
-        logger.log('error', err.stack);
-        return 'There was an internal server error. Please try again.';
-    }
-}
-
 /**
  * Gets the classes a user owns from their email.
  * @param email
@@ -357,7 +214,6 @@ async function getEmailFromAPIKey(api) {
 
 module.exports = {
     getUser,
-    deleteUser,
     getUserOwnedClasses,
     getUserClass
 }

--- a/modules/user/userSession.js
+++ b/modules/user/userSession.js
@@ -1,0 +1,152 @@
+const { userSockets, managerUpdate } = require("../socketUpdates");
+const { classInformation } = require("../class/classroom");
+const { database, dbGet, dbRun } = require("../database");
+const { logger } = require("../logger");
+const { userSocketUpdates } = require("../../sockets/init");
+const { deleteCustomPolls } = require("../polls");
+const { deleteRooms } = require("../class/class");
+const { lastActivities } = require("../../sockets/middleware/inactivity");
+
+function logout(socket) {
+    const email = socket.request.session.email
+    const userId = socket.request.session.userId
+    const classId = socket.request.session.classId
+
+    // Remove this socket from the user's active sockets first and determine if this was the last one
+    let isLastSession = false;
+    if (userSockets[email]) {
+        delete userSockets[email][socket.id];
+        if (Object.keys(userSockets[email]).length === 0) {
+            delete userSockets[email];
+            isLastSession = true;
+        }
+    } else {
+        isLastSession = true;
+    }
+
+    // Leave the room only on this socket
+    if (classId) socket.leave(`class-${classId}`)
+
+    socket.request.session.destroy((err) => {
+        try {
+            if (err) throw err
+
+            // Reload just this client
+            socket.emit('reload')
+
+            // If the socket had an associated last activity, remove it
+            if (lastActivities[email] && lastActivities[email][socket.id]) {
+                delete lastActivities[email][socket.id];
+            }
+
+            // Only clear global user/class state if this was the last active session
+            if (isLastSession) {
+                const user = classInformation.users[email];
+                if (user) {
+                    user.activeClass = null;
+                    user.classPermissions = null;
+                }
+
+                // If the user was not in a class, then return
+                if (!classId) return;
+
+                // If the class is loaded, then mark the user as offline
+                const classroom = classInformation.classrooms[classId];
+                if (classroom) {
+                    const student = classroom.students[email];
+                    if (student) {
+                        if (student.isGuest) {
+                            delete classroom.students[email];
+                        } else {
+                            student.activeClass = null;
+                            student.tags = student.tags ? student.tags + ',Offline' : 'Offline';
+                        }
+                    }
+
+                    // Update class permissions and virtual bar
+                    this.classUpdate(classId);
+                }
+
+                // If this user owns the classroom, end it
+                database.get(
+                    'SELECT * FROM classroom WHERE owner=? AND id=?',
+                    [userId, classId],
+                    (err, classroom) => {
+                        if (err) {
+                            logger.log('error', err.stack)
+                        }
+
+                        if (classroom) {
+                            endClass(classroom.id);
+                        }
+                    }
+                )
+            }
+        } catch (err) {
+            logger.log('error', err.stack)
+        }
+    })
+}
+
+async function deleteUser(userId, userSession) {
+    try {
+        logger.log('info', `[deleteUser] session=(${JSON.stringify(userSession)})`)
+        logger.log('info', `[deleteUser] userId=(${userId})`)
+
+        // Get the user's email from their ID and verify they exist
+        const user = await dbGet('SELECT * FROM users WHERE id=?', [userId]);
+        if (!user) {
+            return 'User not found'
+        }
+
+        // Log the user out if they're currently online
+        const userSocketsMap = userSockets[user.email];
+        const usersSocketUpdates = userSocketUpdates[user.email];
+        if (userSocketsMap && usersSocketUpdates) {
+            const anySocket = Object.values(userSocketsMap)[0];
+            if (anySocket) {
+                logout(anySocket);
+            }
+        }
+
+        try {
+            await dbRun('BEGIN TRANSACTION')
+            await Promise.all([
+                dbRun('DELETE FROM users WHERE id=?', userId),
+                dbRun('DELETE FROM classusers WHERE studentId=?', userId),
+                dbRun('DELETE FROM shared_polls WHERE userId=?', userId),
+            ])
+
+            // await userSocketUpdates.deleteCustomPolls(userId)
+            await deleteCustomPolls(userId)
+            await deleteRooms(userId) // Delete any rooms owned by the user
+
+            // If the student is online, remove them from any class they're in and update the control panel
+            const student = classInformation.users[user.email];
+            if (student) {
+                const activeClass = classInformation.users[user.email].activeClass;
+                const classroom = classInformation.classrooms[activeClass];
+                delete classInformation.users[user.email];
+                if (classroom) {
+                    delete classroom.students[user.email];
+                    userSocketUpdates.classUpdate();
+                }
+            }
+
+            await dbRun('COMMIT')
+            await managerUpdate()
+            return true
+        } catch (err) {
+            await dbRun('ROLLBACK')
+            throw err
+        }
+    } catch (err) {
+        logger.log('error', err.stack);
+        return 'There was an internal server error. Please try again.';
+    }
+}
+
+module.exports = {
+    logout,
+    deleteUser
+}

--- a/modules/user/userSession.js
+++ b/modules/user/userSession.js
@@ -6,6 +6,7 @@ const { userSocketUpdates } = require("../../sockets/init");
 const { deleteCustomPolls } = require("../polls");
 const { deleteRooms } = require("../class/class");
 const { lastActivities } = require("../../sockets/middleware/inactivity");
+const {GUEST_PERMISSIONS} = require("../permissions");
 
 function logout(socket) {
     const email = socket.request.session.email
@@ -47,6 +48,11 @@ function logout(socket) {
                     user.classPermissions = null;
                 }
 
+                // If the user is a guest, then remove them from the global user list
+                if (user.permissions === GUEST_PERMISSIONS) {
+                    delete classInformation.users[email];
+                }
+
                 // If the user was not in a class, then return
                 if (!classId) return;
 
@@ -64,7 +70,10 @@ function logout(socket) {
                     }
 
                     // Update class permissions and virtual bar
-                    this.classUpdate(classId);
+                    const socketUpdates = userSocketUpdates[email];
+                    if (socketUpdates) {
+                        socketUpdates.classUpdate(classId);
+                    }
                 }
 
                 // If this user owns the classroom, end it

--- a/routes/api.js
+++ b/routes/api.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const router = express.Router()
 const { logger } = require('../modules/logger');
 const { GUEST_PERMISSIONS } = require('../modules/permissions');
-const { getUser } = require('../modules/user');
+const { getUser } = require('../modules/user/user');
 
 module.exports = {
 	run(app) {

--- a/routes/api/apiPermissionCheck.js
+++ b/routes/api/apiPermissionCheck.js
@@ -1,5 +1,5 @@
 const { classInformation, getClassIDFromCode } = require("../../modules/class/classroom")
-const { getUser } = require("../../modules/user")
+const { getUser } = require("../../modules/user/user")
 const { logger } = require("../../modules/logger")
 
 module.exports = {

--- a/routes/api/class/end.js
+++ b/routes/api/class/end.js
@@ -1,5 +1,5 @@
 const { logger } = require("../../../modules/logger");
-const { httpPermCheck, classPermCheck } = require("../../middleware/permissionCheck");
+const { classPermCheck } = require("../../middleware/permissionCheck");
 const { endClass } = require("../../../modules/class/class");
 const { CLASS_PERMISSIONS } = require("../../../modules/permissions");
 

--- a/routes/api/user/delete.js
+++ b/routes/api/user/delete.js
@@ -1,6 +1,6 @@
 const { logger } = require("../../../modules/logger");
 const { httpPermCheck } = require("../../middleware/permissionCheck");
-const { deleteUser } = require("../../../modules/user/user");
+const { deleteUser } = require("../../../modules/user/userSession");
 
 module.exports = {
     run(router) {

--- a/routes/api/user/delete.js
+++ b/routes/api/user/delete.js
@@ -1,6 +1,6 @@
 const { logger } = require("../../../modules/logger");
 const { httpPermCheck } = require("../../middleware/permissionCheck");
-const { deleteUser } = require("../../../modules/user");
+const { deleteUser } = require("../../../modules/user/user");
 
 module.exports = {
     run(router) {

--- a/routes/api/user/ownedClasses.js
+++ b/routes/api/user/ownedClasses.js
@@ -1,6 +1,6 @@
 const { logger } = require("../../../modules/logger")
 const { dbGet } = require("../../../modules/database");
-const { getUserOwnedClasses} = require("../../../modules/user");
+const { getUserOwnedClasses} = require("../../../modules/user/user");
 const { httpPermCheck } = require("../../middleware/permissionCheck");
 
 module.exports = {

--- a/routes/middleware/authentication.js
+++ b/routes/middleware/authentication.js
@@ -102,8 +102,6 @@ function isVerified(req, res, next) {
 	}
 }
 
-
-
 // Check if user has the permission levels to enter that page
 function permCheck(req, res, next) {
 	try {

--- a/routes/oauth.js
+++ b/routes/oauth.js
@@ -3,7 +3,7 @@ const { classInformation } = require('../modules/class/classroom');
 const { logNumbers, privateKey } = require('../modules/config');
 const { database, dbGetAll, dbGet } = require('../modules/database');
 const { logger } = require('../modules/logger');
-const { getUserClass } = require('../modules/user');
+const { getUserClass } = require('../modules/user/user');
 const config = require('../modules/config');
 const jwt = require('jsonwebtoken');
 

--- a/sockets/managerPanel.js
+++ b/sockets/managerPanel.js
@@ -2,7 +2,7 @@ const { classInformation } = require("../modules/class/classroom")
 const { database, dbRun, dbGetAll } = require("../modules/database")
 const { logger } = require("../modules/logger")
 const { TEACHER_PERMISSIONS } = require("../modules/permissions")
-const { getUserClass } = require("../modules/user")
+const { getUserClass } = require("../modules/user/user")
 const { io } = require("../modules/webServer")
 const jwt = require("jsonwebtoken");
 

--- a/sockets/middleware/api.js
+++ b/sockets/middleware/api.js
@@ -3,7 +3,7 @@ const { database } = require("../../modules/database")
 const { logger } = require("../../modules/logger")
 const { userSockets } = require("../../modules/socketUpdates")
 const { Student } = require("../../modules/student")
-const { getUserClass } = require("../../modules/user")
+const { getUserClass } = require("../../modules/user/user")
 
 module.exports = {
     order: 10,

--- a/sockets/middleware/inactivity.js
+++ b/sockets/middleware/inactivity.js
@@ -1,5 +1,5 @@
 const { logger } = require("../../modules/logger")
-const INACTIVITY_LIMIT = 30 * 60 * 1000; // 30 minutes
+const INACTIVITY_LIMIT = 60 * 60 * 1000; // 60 minutes
 const lastActivities = {};
 
 module.exports = {

--- a/sockets/pollShare.js
+++ b/sockets/pollShare.js
@@ -2,7 +2,7 @@ const { classInformation } = require("../modules/class/classroom")
 const { database } = require("../modules/database")
 const { logger } = require("../modules/logger")
 const { advancedEmitToClass } = require("../modules/socketUpdates")
-const { getUserClass } = require("../modules/user")
+const { getUserClass } = require("../modules/user/user")
 
 module.exports = {
     run(socket, socketUpdates) {

--- a/sockets/user.js
+++ b/sockets/user.js
@@ -1,21 +1,21 @@
 const { logger } = require("../modules/logger")
+const { logout } = require('../modules/user/userSession')
 
 module.exports = {
     run(socket, socketUpdates) {
         socket.on('getOwnedClasses', (email) => {
-            logger.log('info', `[getOwnedClasses] ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`)
-            logger.log('info', `[getOwnedClasses] email=(${email})`)
+            logger.log('info', `[getOwnedClasses] ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`);
+            logger.log('info', `[getOwnedClasses] email=(${email})`);
 
-            socketUpdates.getOwnedClasses(email)
+            socketUpdates.getOwnedClasses(email);
         })
 
         socket.on('logout', () => {
             try {
-                logger.log('info', `[logout] ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`)
-
-                socketUpdates.logout(socket)
+                logger.log('info', `[logout] ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`);
+                logout(socket);
             } catch (err) {
-                logger.log('error', err.stack)
+                logger.log('error', err.stack);
             }
         })
     }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -358,7 +358,6 @@ dialog {
 #muteButton,
 #unmuteButton {
     display: none;
-	margin-right: 0;
 }
 
 #logoutIcon {

--- a/static/js/controlPanelStudents.js
+++ b/static/js/controlPanelStudents.js
@@ -287,7 +287,7 @@ function buildStudent(classroom, studentData) {
             }
             digipogButtons.appendChild(sendDigipogs)
         } else {
-            digipogButtons.style = 'display: none'
+            digipogButtons.style.display = 'none'
         }
 
         // Ban and Kick buttons

--- a/static/js/controlPanelStudents.js
+++ b/static/js/controlPanelStudents.js
@@ -261,29 +261,34 @@ function buildStudent(classroom, studentData) {
         }
 
         // Digipog awarding
-        let digipogAwardInput = document.createElement('input');
-        digipogAwardInput.className = 'quickButton revampButton revampWithText digipogAward'
-        digipogAwardInput.placeholder = '0'
-        digipogAwardInput.type = 'number'
-        digipogAwardInput.min = 0
-        digipogAwardInput.value = ''
-        digipogAwardInput.max = 999;
-        digipogAwardInput.oninput = (event) => {
-            if (digipogAwardInput.value > 999) digipogAwardInput.value = 999
-            if (digipogAwardInput.value < 0) digipogAwardInput.value = 0
-            if (digipogAwardInput.value == '') digipogAwardInput.value = 0
-            digipogAwardInput.value = parseInt(digipogAwardInput.value)
-        }
-        digipogButtons.appendChild(digipogAwardInput)
+        // If the user is not a guest, allow awarding digipogs
+        if (studentData.permissions !== GUEST_PERMISSIONS) {
+            let digipogAwardInput = document.createElement('input');
+            digipogAwardInput.className = 'quickButton revampButton revampWithText digipogAward'
+            digipogAwardInput.placeholder = '0'
+            digipogAwardInput.type = 'number'
+            digipogAwardInput.min = 0
+            digipogAwardInput.value = ''
+            digipogAwardInput.max = 999;
+            digipogAwardInput.oninput = (event) => {
+                if (digipogAwardInput.value > 999) digipogAwardInput.value = 999
+                if (digipogAwardInput.value < 0) digipogAwardInput.value = 0
+                if (digipogAwardInput.value == '') digipogAwardInput.value = 0
+                digipogAwardInput.value = parseInt(digipogAwardInput.value)
+            }
+            digipogButtons.appendChild(digipogAwardInput)
 
-        let sendDigipogs = document.createElement('button')
-        sendDigipogs.className = 'quickButton revampButton acceptButton digipogSend'
-        sendDigipogs.setAttribute('data-user', studentData.id)
-        sendDigipogs.textContent = 'Award Digipogs'
-        sendDigipogs.onclick = (event) => {
-            awardDigipogs(studentData.id, digipogAwardInput.value)
+            let sendDigipogs = document.createElement('button')
+            sendDigipogs.className = 'quickButton revampButton acceptButton digipogSend'
+            sendDigipogs.setAttribute('data-user', studentData.id)
+            sendDigipogs.textContent = 'Award Digipogs'
+            sendDigipogs.onclick = (event) => {
+                awardDigipogs(studentData.id, digipogAwardInput.value)
+            }
+            digipogButtons.appendChild(sendDigipogs)
+        } else {
+            digipogButtons.style = 'display: none'
         }
-        digipogButtons.appendChild(sendDigipogs)
 
         // Ban and Kick buttons
         let banStudentButton = document.createElement('button')

--- a/views/partials/formbar_header.ejs
+++ b/views/partials/formbar_header.ejs
@@ -32,7 +32,7 @@
 		<% } %>
 	<% } %>
 		</ul>
-	<button class="circularButton" onclick="doFullscreen()"><img id="muteIcon" src="/img/expand-outline.svg" title="Fullscreen"></button>
+	<button class="circularButton" onclick="doFullscreen()"><img src="/img/expand-outline.svg" title="Fullscreen"></button>
 
 	<button onclick="toggleTheme()" id="lmdmBtn" class="circularButton" title="LM/DM">
 		<img id="lmdmIcon" src="/img/sun.svg" title="Light/Dark Mode Toggle">
@@ -44,12 +44,14 @@
 	<script>if(!window.location.href.includes('controlPanel')){document.getElementById('muteButton').remove();document.getElementById('unmuteButton').remove()}</script>
 
 	<% if(locals.currentUser) { %>
-		<button class="mobileMenuButton circularButton" style="margin-left: 10px;" onclick="document.getElementById('mobileNavigation').classList.toggle('open');">
+		<button class="mobileMenuButton circularButton" onclick="document.getElementById('mobileNavigation').classList.toggle('open');">
 			<img src="/img/menu.svg" alt="Menu Icon">
 		</button>
-		<a href="/profile" class="circularButton hideMobile" style="margin-left: 20px;" title="LM/DM">
-			<img src="/img/person.svg" title="Profile">
-		</a>
+        <% if (locals.currentUser.permissions !== GUEST_PERMISSIONS) { %>
+            <a href="/profile" class="circularButton hideMobile" title="LM/DM">
+                <img src="/img/person.svg" title="Profile">
+            </a>
+        <% } %>
 		<button href="/" id="logoutButton" class="circularButton hideMobile" onclick="logout()">
 			<img id="logoutIcon" src="/img/logout.svg" title="Logout">
 		</button>


### PR DESCRIPTION
Fixed #753

- Guests no longer break permission switching after leaving a room
- Guests can no longer visit the /profile page or see the button to go there
- Guest accounts are no longer destroyed entirely when leaving a class or room. They're only destroyed from that room.
- The award digipog area no longer shows up for guests on the teacher control panel
- Clicking the switch all button with guests in the room no longer errors
- Fixed students being unable to refresh their PIN due to a permission error