### PR TITLE
Fix user API can't change classes after error 

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,8 +83,22 @@ setInterval(() => {
         const userSockets = lastActivities[email];
         for (const [socketId, activity] of Object.entries(userSockets)) {
             if (currentTime - activity.time > INACTIVITY_LIMIT) {
-                logout(activity.socket); // Log the user out
-                delete lastActivities[email]; // Remove the user from the inactivity check
+                // Check if this is an API socket - API sockets should not timeout
+                let isApiSocket = false;
+                if (activity.socket && activity.socket.rooms) {
+                    for (const room of activity.socket.rooms) {
+                        if (room.startsWith("api-")) {
+                            isApiSocket = true;
+                            break;
+                        }
+                    }
+                }
+
+                // Only logout non-API sockets
+                if (!isApiSocket) {
+                    logout(activity.socket); // Log the user out
+                    delete lastActivities[email]; // Remove the user from the inactivity check
+                }
             }
         }
     }

--- a/modules/socketUpdates.js
+++ b/modules/socketUpdates.js
@@ -105,7 +105,7 @@ async function setClassOfApiSockets(api, classId) {
 
             // Emit the setClass event to the socket
             socket.join(`class-${classId}`);
-            socket.emit("setClass", socket.request.session.classId);
+            socket.emit("setClass", classId);
         }
     } catch (err) {
         logger.log("error", err.stack);


### PR DESCRIPTION
Fixes #866 

- Added a check to ensure the socket's session is defined before performing any actions in setClassOfApiSockets
- Excluded API sockets from the inactivity check due to them being logged out, thus not working