### PR TITLE
Fix unselected users being able to vote

### DIFF
--- a/modules/socketUpdates.js
+++ b/modules/socketUpdates.js
@@ -266,8 +266,7 @@ function getClassUpdateData(classData, hasTeacherPermissions, options = { restri
         isActive: classData.isActive,
         timer: classData.timer,
         poll: {
-            ...classData.poll,
-            excludedRespondents: hasTeacherPermissions ? classData.poll.excludedRespondents : undefined,
+            ...classData.poll
         },
         permissions: hasTeacherPermissions ? classData.permissions : undefined,
         key: hasTeacherPermissions ? classData.key : undefined,

--- a/static/js/controlPanelPolls.js
+++ b/static/js/controlPanelPolls.js
@@ -451,6 +451,8 @@ function startPoll(customPollId) {
     let multiRes = document.getElementById("multiRes");
     let selectTagForm = document.getElementsByName("selectTagForm");
     let allCheckboxes = document.getElementsByName("studentCheckbox");
+    let userExcludedRespondents = [];
+
     for (let eachTagForm of selectTagForm[0]) {
         if (eachTagForm.checked) {
             //for each tag checked on the teacher's side to determine who can answer the poll, add it to the userTags array
@@ -462,6 +464,10 @@ function startPoll(customPollId) {
         if (eachBox.checked && !eachBox.indeterminate) {
             let boxId = Number(eachBox.id.split("_")[1]);
             userBoxesChecked.push(boxId);
+        } else if (!eachBox.indeterminate) {
+            // Checkbox is unchecked, so this student is excluded from the poll
+            let boxId = Number(eachBox.id.split("_")[1]);
+            userExcludedRespondents.push(boxId);
         }
         if (eachBox.indeterminate) {
             let boxId = Number(eachBox.id.split("_")[1]);
@@ -471,6 +477,7 @@ function startPoll(customPollId) {
 
     userTags.sort();
     userBoxesChecked.sort();
+    userExcludedRespondents.sort();
     userIndeterminate.sort();
     userBreak.sort();
 
@@ -502,6 +509,7 @@ function startPoll(customPollId) {
             weight: customPoll.weight,
             tags: userTags,
             indeterminate: customPoll.indeterminate,
+            excludedRespondents: userExcludedRespondents,
         });
     } else {
         socket.emit("startPoll", {
@@ -514,6 +522,7 @@ function startPoll(customPollId) {
             weight: 1,
             tags: userTags,
             indeterminate: userIndeterminate,
+            excludedRespondents: userExcludedRespondents,
         });
     }
     clearPoll.style.display = "block";

--- a/views/pages/student.ejs
+++ b/views/pages/student.ejs
@@ -170,7 +170,9 @@
 			votingRight = false;
 			return;
 		}
-		
+
+        console.log(classroomData);
+
 		// Check if student has the "Excluded" tag
 		if (classroomData && classroomData.myTags && Array.isArray(classroomData.myTags) && classroomData.myTags.includes("Excluded")) {
 			votingRight = false;
@@ -261,6 +263,7 @@
 			// If user cannot vote
 			const mayNotAnswer = document.getElementById('pollControl');
 			const noVoteReason = getNoVoteReason(classroomData);
+            console.log('VOTING RIGHTS:', votingRight, noVoteReason)
 			if (!votingRight || noVoteReason !== "You may not answer currently") {
 				pollForm.innerHTML = `<label class="form-control" id="pollControl" style="--theme-color: hsl(0, 0%, 70%);">${noVoteReason}</label>`;
 				return;


### PR DESCRIPTION
Fixed issue outlined in the comments of #835

- excludedRespondents is no longer hidden from students.
    - excludedRespondents was accidentally hidden from students as a result of #872, thus unselected students still saw the poll options. From testing, they were not actually able to vote due to the backend check.