### PR TITLE
Incorrect Redirecting for Multiple Tabs

### DIFF
--- a/database/migrations/JSMigrations/02_update_classusers.js
+++ b/database/migrations/JSMigrations/02_update_classusers.js
@@ -2,7 +2,7 @@
 // This migration removes the 'digipogs' column from the 'classusers' table
 // and adds a new 'tags' column to the same table.
 
-const { dbGetAll } = require("../../../modules/database");
+const { dbGetAll, dbRun } = require("../../../modules/database");
 module.exports = {
     async run(database) {
         const columns = await dbGetAll("PRAGMA table_info(classusers)", [], database);

--- a/routes/controlPanel.js
+++ b/routes/controlPanel.js
@@ -17,7 +17,7 @@ module.exports = {
                 const classId = user && user.activeClass != null ? user.activeClass : req.session.classId;
                 const classroom = classInformation.classrooms[classId];
                 if (!classroom) {
-                    return res.redirect("/manageClass");
+                    return res.redirect("/selectClass");
                 }
 
                 /* 


### PR DESCRIPTION
Issue #876
I changed the redirection (for when you exit or change classes via utilizing the "Classes" button at the top) from the old "/manageClass" endpoint to the new "/selectClass" endpoint for all instances, even for when multiple tabs of Formbar are open at once.