### PR TITLE
Fix duplicate classes on /selectClass

### DIFF
--- a/modules/socketUpdates.js
+++ b/modules/socketUpdates.js
@@ -1,5 +1,5 @@
 const { classInformation } = require("./class/classroom");
-const { database } = require("./database");
+const { database, dbGetAll } = require("./database");
 const { logger } = require("./logger");
 const { TEACHER_PERMISSIONS, CLASS_SOCKET_PERMISSIONS, GUEST_PERMISSIONS, MANAGER_PERMISSIONS, MOD_PERMISSIONS } = require("./permissions");
 const { getManagerData } = require("./manager");
@@ -494,21 +494,16 @@ class SocketUpdates {
         }
     }
 
-    getOwnedClasses(email) {
+    async getOwnedClasses(email) {
         try {
             logger.log("info", `[getOwnedClasses] email=(${email})`);
 
-            database.all("SELECT name, id FROM classroom WHERE owner=?", [classInformation.users[email].id], (err, ownedClasses) => {
-                try {
-                    if (err) throw err;
+            // Get the user's owned classes from the database
+            const ownedClasses = await dbGetAll("SELECT name, id FROM classroom WHERE owner=?", [classInformation.users[email].id]);
+            logger.log("info", `[getOwnedClasses] ownedClasses=(${JSON.stringify(ownedClasses)})`);
 
-                    logger.log("info", `[getOwnedClasses] ownedClasses=(${JSON.stringify(ownedClasses)})`);
-
-                    io.to(`user-${email}`).emit("getOwnedClasses", ownedClasses);
-                } catch (err) {
-                    logger.log("error", err.stack);
-                }
-            });
+            // Send the owned classes to the user's sockets
+            io.to(`user-${email}`).emit("getOwnedClasses", ownedClasses);
         } catch (err) {
             logger.log("error", err.stack);
         }

--- a/routes/api/user/user.js
+++ b/routes/api/user/user.js
@@ -15,8 +15,9 @@ module.exports = {
                 let user = Object.values(classInformation.users).find((user) => user.id == userId);
                 if (!user) {
                     user = await dbGet("SELECT * FROM users WHERE id=?", userId);
-                } else { // Load missing digipogs and verified values from the database
-                    const {digipogs, verified} = await dbGet("SELECT digipogs, verified FROM users WHERE id=?", userId) || {};
+                } else {
+                    // Load missing digipogs and verified values from the database
+                    const { digipogs, verified } = (await dbGet("SELECT digipogs, verified FROM users WHERE id=?", userId)) || {};
                     user.digipogs = digipogs;
                     user.verified = verified;
                 }

--- a/views/pages/classes.ejs
+++ b/views/pages/classes.ejs
@@ -89,7 +89,7 @@
 
             if (currentUser && currentUser.permissions >= TEACHER_PERMISSIONS) {
                 socket.emit('getOwnedClasses', currentUser.email)
-                socket.on('getOwnedClasses', (ownedClasses) => {
+                socket.once('getOwnedClasses', (ownedClasses) => {
                     if (ownedClasses.length > 0) {
                         //startClassForm.style.opacity = "1"
                         //startClassForm.style.pointerEvents = "all";


### PR DESCRIPTION
Fixes #893
The getOwnedClasses socket event is now set to only be received once. Previously, having multiple sessions would cause it to be emitted multiple times, resulting in duplicate classes showing up.