### PR TITLE
Fix 01_convert_users.sql migration

### DIFF
--- a/database/migrations/01_convert_users.sql
+++ b/database/migrations/01_convert_users.sql
@@ -27,9 +27,6 @@ CREATE TABLE IF NOT EXISTS "users_temp"
     PRIMARY KEY ("id" AUTOINCREMENT)
 );
 
-ALTER TABLE users ADD COLUMN email DEFAULT "";
-ALTER TABLE users ADD COLUMN digipogs DEFAULT 0;
-ALTER TABLE users ADD COLUMN verified DEFAULT 0;
 ALTER TABLE users ADD COLUMN pin DEFAULT NULL;
 
 INSERT INTO users_temp (
@@ -40,7 +37,7 @@ SELECT
     COALESCE(email, id || '@placeholder.com') AS email,  -- keep existing email if present, otherwise use placeholder
     digipogs,
     verified,
-    pin
+    COALESCE(pin, NULL) AS pin
 FROM users;
 
 DROP TABLE users;

--- a/modules/config.js
+++ b/modules/config.js
@@ -60,15 +60,16 @@ function getConfig() {
     // If there is no .env file, create one from the template
     if (!fs.existsSync(".env")) fs.copyFileSync(".env-template", ".env");
 
-    dbGet("SELECT * FROM digipog_pools WHERE id = 0").then((formbarDevPool) => {
+    // Ensure the Formbar Developer Pool exists in the database
+    dbGet("SELECT * FROM digipog_pools WHERE id = 0").then(async (formbarDevPool) => {
         if (!formbarDevPool) {
-            dbRun("INSERT INTO digipog_pools (id, name, description, amount) VALUES (?, ?, ?, ?)", [
+            await dbRun("INSERT INTO digipog_pools (id, name, description, amount) VALUES (?, ?, ?, ?)", [
                 0,
                 "Formbar Developer Pool",
                 "Formbar Developer pog pool. Accumulates from the 10% tax on digipog transactions.",
                 0,
             ]);
-            dbRun("INSERT INTO digipog_pool_users (id, owner) VALUES (?, ?)", [1, "0"]);
+            await dbRun("INSERT INTO digipog_pool_users (pool_id, user_id, owner) VALUES (?, ?, ?)", [0, 1, 1]);
         }
     });
 


### PR DESCRIPTION
Fixes #897 

Previously, the migration would fail due to creating duplicate columns, causing new databases to fail when creating accounts.
The migration no longer tries to create columns that already exist.