### PR TITLE
Fix REST API Key Comparison

### DIFF
--- a/modules/user/user.js
+++ b/modules/user/user.js
@@ -184,7 +184,7 @@ async function getEmailFromAPIKey(api) {
 
                     if (!userData) {
                         logger.log("verbose", "[getEmailFromAPIKeyClass] not a valid API Key");
-                        resolve({error: "Not a valid API key"});
+                        resolve({ error: "Not a valid API key" });
                         return;
                     }
                     resolve(userData);

--- a/routes/api/user/user.js
+++ b/routes/api/user/user.js
@@ -26,9 +26,7 @@ module.exports = {
                 const requesterEmail = req.session.email;
                 let userEmail = undefined;
                 // Safer check for manager permissions
-                const isManager =
-                    requesterEmail &&
-                    (classInformation.users[requesterEmail]?.permissions === MANAGER_PERMISSIONS);
+                const isManager = requesterEmail && classInformation.users[requesterEmail]?.permissions === MANAGER_PERMISSIONS;
                 if (user && (requesterEmail === user.email || isManager)) {
                     userEmail = user.email;
                 }


### PR DESCRIPTION
When using REST API, the user's API key is not properly compared against their hashed API key in the database.