### PR TITLE
Fix for accordion not opening furthest to left button.

### DIFF
--- a/static/js/controlPanelStudents.js
+++ b/static/js/controlPanelStudents.js
@@ -39,7 +39,8 @@ function buildStudent(classroomData, studentData) {
 
         newStudent.addEventListener("toggle", () => {
             if (newStudent.open) {
-                targetButton = newStudent.querySelector("button.accordionButton:not(.accButtonDisabled)");
+                if (opendetails.indexOf(studentData.id) == -1) opendetails.push(studentData.id);
+                let targetButton = newStudent.querySelector("button.accordionButton:not(.accButtonDisabled)");
                 doAccordionButton(targetButton, true);
             } else {
                 opendetails.splice(opendetails.indexOf(studentData.id), 1);


### PR DESCRIPTION
This pull request fixes the accordion buttons by now opening the more important menu first, or the menu that is furthest to the left.