### PR TITLE
Fix /apiPermissionCheck endpoint

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -15,7 +15,7 @@ module.exports = {
                     logger.log("info", `[isAuthenticated] ip=(${req.ip}) session=(${JSON.stringify(res.session)})`);
 
                     // Allow digipogs endpoints without authentication
-                    if ((req.path && req.path.startsWith("/digipogs/"))) {
+                    if (req.path && req.path.startsWith("/digipogs/")) {
                         return next();
                     }
 


### PR DESCRIPTION
Completes #903 
The `getUser` function call within the endpoint now sends the proper arguments.