### PR TITLE
Add cors to WebSockets

### DIFF
--- a/modules/webServer.js
+++ b/modules/webServer.js
@@ -7,7 +7,12 @@ const { dbGetAll } = require("./database");
 function createServer() {
     const app = express();
     const http = require("http").createServer(app);
-    const io = require("socket.io")(http);
+    const io = require("socket.io")(http, {
+        cors: {
+            origin: "*",
+        },
+    });
+
     const swaggerDocOptions = {
         definition: {
             openapi: "3.0.0",


### PR DESCRIPTION
Fixes issue #958 
This PR specifies cors for websockets, allowing the frontend to properly connect and use events.