### PR TITLE
Add lowercase email migration

### DIFF
--- a/database/migrations/JSMigrations/12_lowercase_emails_merge_duplicates.js
+++ b/database/migrations/JSMigrations/12_lowercase_emails_merge_duplicates.js
@@ -100,5 +100,6 @@ module.exports = {
             await dbRun("ROLLBACK", [], database);
             throw err;
         }
+		await dbRun("COMMIT", [], database);
     },
 };


### PR DESCRIPTION
This PR adds a migration to make everyone's emails lowercase.
If there are multiple accounts with the same email, the first account stays, and the others get merged into it.