### PR TITLE
Fix users not being attached to a SocketUpdates class

### DIFF
--- a/modules/class/help.js
+++ b/modules/class/help.js
@@ -1,8 +1,7 @@
 const { classInformation } = require("./classroom");
 const { logger } = require("../logger");
-const { advancedEmitToClass, emitToUser } = require("../socket-updates");
+const { advancedEmitToClass, emitToUser, userUpdateSocket } = require("../socket-updates");
 const { getEmailFromId } = require("../student");
-const { userSocketUpdates } = require("../../sockets/init");
 
 function sendHelpTicket(reason, userSession) {
     try {
@@ -32,11 +31,7 @@ function sendHelpTicket(reason, userSession) {
 
         logger.log("verbose", `[help] user=(${JSON.stringify(student)}`);
 
-        // @TODO: TEMP FIX
-        for (const socketUpdates of Object.values(userSocketUpdates[email])) {
-            socketUpdates.classUpdate(classId);
-            break;
-        }
+        userUpdateSocket(email, "classUpdate", classId);
         return true;
     } catch (err) {
         logger.log("error", err.stack);
@@ -55,11 +50,7 @@ async function deleteHelpTicket(studentId, userData) {
         classInformation.classrooms[classId].students[studentEmail].help = false;
         logger.log("verbose", `[deleteTicket] user=(${JSON.stringify(classInformation.classrooms[classId].students[studentEmail])})`);
 
-        // @TODO: TEMP FIX
-        for (const socketUpdates of Object.values(userSocketUpdates[email])) {
-            socketUpdates.classUpdate(classId);
-            break;
-        }
+        userUpdateSocket(email, "classUpdate", classId);
         return true;
     } catch (err) {
         logger.log("error", err.stack);

--- a/modules/socket-updates.js
+++ b/modules/socket-updates.js
@@ -37,11 +37,12 @@ async function userUpdateSocket(email, methodName, ...args) {
     const { userSocketUpdates } = require("../sockets/init");
 
     // If user has no socket connections yet, then return
-    if (!userSocketUpdates || !userSocketUpdates[email] || Object.keys(userSocketUpdates[email]).length === 0) {
+    const userSockets = userSocketUpdates.get(email);
+    if (!userSockets || userSockets.size === 0) {
         return;
     }
 
-    for (const socketUpdates of Object.values(userSocketUpdates[email])) {
+    for (const socketUpdates of userSockets.values()) {
         if (socketUpdates && typeof socketUpdates[methodName] === "function") {
             socketUpdates[methodName](...args);
         }

--- a/services/class-service.js
+++ b/services/class-service.js
@@ -1,6 +1,6 @@
 const { dbGetAll, dbGet, dbRun } = require("@modules/database");
 const { logger } = require("@modules/logger");
-const { advancedEmitToClass, userSockets, setClassOfApiSockets, userUpdateSocket } = require("@modules/socket-updates");
+const { advancedEmitToClass, userSockets, setClassOfApiSockets, setClassOfUserSockets, userUpdateSocket } = require("@modules/socket-updates");
 const { classInformation, Classroom } = require("@modules/class/classroom");
 const {
     MANAGER_PERMISSIONS,
@@ -421,6 +421,10 @@ async function addUserToClassroomSession(classId, email, sessionUser) {
         // Set the class of the API socket
         setClassOfApiSockets(currentUser.API, classId);
 
+        // Move all user sockets (session-based and JWT-based) to the new class room
+        // This ensures sockets receive classUpdate emissions when joining via HTTP
+        setClassOfUserSockets(email, classId);
+
         // Call classUpdate on all user's tabs
         userUpdateSocket(email, "classUpdate", classId, { global: false, restrictToControlPanel: true });
 
@@ -451,6 +455,10 @@ async function addUserToClassroomSession(classId, email, sessionUser) {
         classInformation.users[email].activeClass = classId;
 
         setClassOfApiSockets(currentUser.API, classId);
+
+        // Move all user sockets (session-based and JWT-based) to the new class room
+        // This ensures sockets receive classUpdate emissions when joining via HTTP
+        setClassOfUserSockets(email, classId);
 
         // Call classUpdate on all user's tabs
         userUpdateSocket(email, "classUpdate", classId, { global: false, restrictToControlPanel: true });

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -162,10 +162,10 @@ async function updatePoll(classId, options, userSession) {
     }
 
     // Broadcast update to all tabs
-    const socketUpdate = userSocketUpdates[userSession.email];
-    for (const socketId in socketUpdate) {
-        socketUpdate[socketId].classUpdate(classId, { global: true });
-        break; // only needs to be called once because it's global
+    const userSockets = userSocketUpdates.get(userSession.email);
+    if (userSockets && userSockets.size > 0) {
+        const firstSocket = userSockets.values().next().value;
+        firstSocket.classUpdate(classId, { global: true });
     }
     return true;
 }

--- a/services/room-service.js
+++ b/services/room-service.js
@@ -93,8 +93,9 @@ async function leaveRoom(userData) {
     }
 
     // Update the class and play leave sound
-    if (userSocketUpdates[email]) {
-        for (const socketUpdate of Object.values(userSocketUpdates[email])) {
+    const userSockets = userSocketUpdates.get(email);
+    if (userSockets) {
+        for (const socketUpdate of userSockets.values()) {
             socketUpdate.classUpdate(classId);
         }
     }

--- a/sockets/init.js
+++ b/sockets/init.js
@@ -1,30 +1,42 @@
 const { SocketUpdates } = require("@modules/socket-updates");
 const { io } = require("@modules/web-server");
 const fs = require("fs");
-const userSocketUpdates = {}; // Stores the socket update events for users (keyed by email, then socket.id)
+
+// Stores the socket update events for users (keyed by email, then socket.id)
+const userSocketUpdates = new Map();
+
+/**
+ * Adds a socket update instance for a user
+ * @param {string} email - User's email
+ * @param {string} socketId - Socket ID
+ * @param {SocketUpdates} socketUpdates - SocketUpdates instance
+ */
+function addUserSocketUpdate(email, socketId, socketUpdates) {
+    if (!userSocketUpdates.has(email)) {
+        userSocketUpdates.set(email, new Map());
+    }
+    userSocketUpdates.get(email).set(socketId, socketUpdates);
+}
+
+/**
+ * Removes a socket update instance for a user and cleans up if no more sockets
+ * @param {string} email - User's email
+ * @param {string} socketId - Socket ID
+ */
+function removeUserSocketUpdate(email, socketId) {
+    const userSockets = userSocketUpdates.get(email);
+    if (userSockets) {
+        userSockets.delete(socketId);
+        if (userSockets.size === 0) {
+            userSocketUpdates.delete(email);
+        }
+    }
+}
 
 // Initializes all the websocket routes
 function initSocketRoutes() {
     io.on("connection", async (socket) => {
         const socketUpdates = new SocketUpdates(socket);
-        if (socket.request.session.email) {
-            const email = socket.request.session.email;
-            // Store multiple socket updates per user, keyed by socket.id
-            if (!userSocketUpdates[email]) {
-                userSocketUpdates[email] = {};
-            }
-            userSocketUpdates[email][socket.id] = socketUpdates;
-
-            // Cleanup on disconnect
-            socket.on("disconnect", () => {
-                if (userSocketUpdates[email] && userSocketUpdates[email][socket.id]) {
-                    delete userSocketUpdates[email][socket.id];
-                    if (Object.keys(userSocketUpdates[email]).length === 0) {
-                        delete userSocketUpdates[email];
-                    }
-                }
-            });
-        }
 
         // Import middleware
         const socketMiddlewareFiles = fs.readdirSync("./sockets/middleware").filter((file) => file.endsWith(".js"));
@@ -65,4 +77,6 @@ function initSocketRoutes() {
 module.exports = {
     initSocketRoutes,
     userSocketUpdates,
+    addUserSocketUpdate,
+    removeUserSocketUpdate,
 };

--- a/sockets/middleware/api.js
+++ b/sockets/middleware/api.js
@@ -9,6 +9,153 @@ const { compare } = require("@modules/crypto");
 const { verifyToken } = require("@services/auth-service");
 const { addUserSocketUpdate, removeUserSocketUpdate } = require("../init");
 
+/**
+ * Ensures a Student instance exists in classInformation for the given user.
+ * Creates a new Student object if one doesn't already exist for the user's email.
+ *
+ * @param {Object} userData - The user data object from the database
+ * @param {string} userData.email - User's email address
+ * @param {number} userData.id - User's unique identifier
+ * @param {number} userData.permissions - User's permission level
+ * @param {string} userData.API - User's API key (hashed)
+ * @param {string} [userData.tags] - Comma-separated list of user tags
+ * @param {string} userData.displayName - User's display name
+ */
+function ensureStudentExists(userData) {
+    if (!classInformation.users[userData.email]) {
+        classInformation.users[userData.email] = new Student(
+            userData.email,
+            userData.id,
+            userData.permissions,
+            userData.API,
+            null,
+            null,
+            userData.tags ? userData.tags.split(",") : [],
+            userData.displayName,
+            false
+        );
+    }
+}
+
+/**
+ * Sets up socket session data for an authenticated user.
+ * Populates the socket's session with user information and retrieves the user's active class.
+ *
+ * @param {Object} socket - The socket.io socket instance
+ * @param {Object} userData - The user data object from the database
+ * @param {string} userData.email - User's email address
+ * @param {number} userData.id - User's unique identifier
+ * @param {string} [userData.API] - User's API key (included if API authentication)
+ * @param {boolean} [includeApi=false] - Whether to include API key in session (for API key auth)
+ */
+function setupSocketSession(socket, userData, includeApi = false) {
+    if (includeApi) {
+        socket.request.session.api = userData.API;
+    }
+    socket.request.session.userId = userData.id;
+    socket.request.session.email = userData.email;
+    socket.request.session.classId = getUserClass(userData.email);
+}
+
+/**
+ * Joins socket to appropriate rooms based on authentication type.
+ * API-authenticated sockets join api-{key} and class-{id} rooms.
+ * JWT/session-authenticated sockets join user-{email} and class-{id} rooms.
+ *
+ * @param {Object} socket - The socket.io socket instance
+ * @param {string} email - User's email address
+ * @param {number|null} classId - The class ID to join, or null if not in a class
+ * @param {boolean} [isApiAuth=false] - Whether this is API key authentication
+ */
+function joinSocketRooms(socket, email, classId, isApiAuth = false) {
+    if (classId) {
+        if (isApiAuth) {
+            socket.join(`api-${socket.request.session.api}`);
+        } else {
+            socket.join(`user-${email}`);
+        }
+        socket.join(`class-${classId}`);
+    }
+}
+
+/**
+ * Tracks user socket connections in the global userSockets object.
+ * Maintains a mapping of email -> socketId -> socket for managing multiple connections per user.
+ *
+ * @param {string} email - User's email address
+ * @param {string} socketId - The socket's unique identifier
+ * @param {Object} socket - The socket.io socket instance
+ */
+function trackUserSocket(email, socketId, socket) {
+    if (!userSockets[email]) {
+        userSockets[email] = {};
+    }
+    userSockets[email][socketId] = socket;
+}
+
+/**
+ * Sets up disconnect handler for socket with proper cleanup logic.
+ * Handles cleanup of socket updates and user tracking, and kicks user from class
+ * when their last socket disconnects.
+ *
+ * @param {Object} socket - The socket.io socket instance
+ * @param {string} email - User's email address
+ * @param {number|null} classId - The class ID the user is in, or null
+ * @param {boolean} [isApiAuth=false] - Whether this is API key authentication
+ */
+function setupDisconnectHandler(socket, email, classId, isApiAuth = false) {
+    socket.on("disconnect", () => {
+        removeUserSocketUpdate(email, socket.id);
+
+        if (isApiAuth) {
+            if (!userSockets[email]) {
+                classKickStudent(email, classId, false);
+            }
+        } else {
+            if (userSockets[email]) {
+                delete userSockets[email][socket.id];
+                if (Object.keys(userSockets[email]).length === 0) {
+                    delete userSockets[email];
+                    classKickStudent(email, classId, false);
+                }
+            }
+        }
+    });
+}
+
+/**
+ * Completes socket authentication setup by orchestrating all authentication steps.
+ * This function ensures the user exists, sets up their session, joins appropriate rooms,
+ * tracks their socket connection, and sets up disconnect handling.
+ *
+ * @param {Object} socket - The socket.io socket instance
+ * @param {Object} userData - The user data object from the database
+ * @param {string} userData.email - User's email address
+ * @param {number} userData.id - User's unique identifier
+ * @param {number} userData.permissions - User's permission level
+ * @param {string} userData.API - User's API key (hashed)
+ * @param {string} [userData.tags] - Comma-separated list of user tags
+ * @param {string} userData.displayName - User's display name
+ * @param {Object} socketUpdates - The SocketUpdates instance for this connection
+ * @param {boolean} [isApiAuth=false] - Whether this is API key authentication
+ */
+function finalizeAuthentication(socket, userData, socketUpdates, isApiAuth = false) {
+    ensureStudentExists(userData);
+    setupSocketSession(socket, userData, isApiAuth);
+
+    const { email, classId } = socket.request.session;
+
+    joinSocketRooms(socket, email, classId, isApiAuth);
+    socket.emit("setClass", classId);
+
+    if (!isApiAuth) {
+        trackUserSocket(email, socket.id, socket);
+    }
+
+    addUserSocketUpdate(email, socket.id, socketUpdates);
+    setupDisconnectHandler(socket, email, classId, isApiAuth);
+}
+
 module.exports = {
     order: 10,
     async run(socket, socketUpdates) {
@@ -37,39 +184,7 @@ module.exports = {
                                 throw "Not a valid API key";
                             }
 
-                            if (!classInformation.users[userData.email]) {
-                                classInformation.users[userData.email] = new Student(
-                                    userData.email,
-                                    userData.id,
-                                    userData.permissions,
-                                    userData.API,
-                                    null,
-                                    null,
-                                    userData.tags ? userData.tags.split(",") : [],
-                                    userData.displayName,
-                                    false
-                                );
-                            }
-
-                            socket.request.session.api = userData.API;
-                            socket.request.session.userId = userData.id;
-                            socket.request.session.email = userData.email;
-                            socket.request.session.classId = getUserClass(userData.email);
-
-                            socket.join(`api-${userData.API}`);
-                            socket.join(`class-${socket.request.session.classId}`);
-                            socket.emit("setClass", socket.request.session.classId);
-
-                            // Track SocketUpdates instance for this user
-                            addUserSocketUpdate(userData.email, socket.id, socketUpdates);
-
-                            socket.on("disconnect", () => {
-                                removeUserSocketUpdate(userData.email, socket.id);
-                                if (!userSockets[socket.request.session.email]) {
-                                    classKickStudent(socket.request.session.email, socket.request.session.classId, false);
-                                }
-                            });
-
+                            finalizeAuthentication(socket, userData, socketUpdates, true);
                             resolve();
                         } catch (err) {
                             reject(err);
@@ -109,46 +224,7 @@ module.exports = {
                                     throw "User not found";
                                 }
 
-                                if (!classInformation.users[userData.email]) {
-                                    classInformation.users[userData.email] = new Student(
-                                        userData.email,
-                                        userData.id,
-                                        userData.permissions,
-                                        userData.API,
-                                        null,
-                                        null,
-                                        userData.tags ? userData.tags.split(",") : [],
-                                        userData.displayName,
-                                        false
-                                    );
-                                }
-
-                                socket.request.session.userId = userData.id;
-                                socket.request.session.email = userData.email;
-                                socket.request.session.classId = getUserClass(userData.email);
-
-                                socket.join(`user-${userData.email}`);
-                                socket.join(`class-${socket.request.session.classId}`);
-                                socket.emit("setClass", socket.request.session.classId);
-
-                                // Track all sockets for the user
-                                if (!userSockets[userData.email]) userSockets[userData.email] = {};
-                                userSockets[userData.email][socket.id] = socket;
-
-                                // Track SocketUpdates instance for this user
-                                addUserSocketUpdate(userData.email, socket.id, socketUpdates);
-
-                                socket.on("disconnect", () => {
-                                    removeUserSocketUpdate(userData.email, socket.id);
-                                    if (userSockets[userData.email]) {
-                                        delete userSockets[userData.email][socket.id];
-                                        if (Object.keys(userSockets[userData.email]).length === 0) {
-                                            delete userSockets[userData.email];
-                                            classKickStudent(userData.email, socket.request.session.classId, false);
-                                        }
-                                    }
-                                });
-
+                                finalizeAuthentication(socket, userData, socketUpdates, false);
                                 resolve();
                             } catch (err) {
                                 reject(err);
@@ -177,8 +253,7 @@ module.exports = {
 
                 // Track all sockets for the user
                 socket.join(`user-${email}`);
-                if (!userSockets[email]) userSockets[email] = {};
-                userSockets[email][socket.id] = socket;
+                trackUserSocket(email, socket.id, socket);
 
                 // Track SocketUpdates instance for this user
                 addUserSocketUpdate(email, socket.id, socketUpdates);


### PR DESCRIPTION
Fixes issue #974 
This PR fixes users not being attached to a `SocketUpdates` class due to logging in through HTTP. Since we removed the use of `req.session`, `socket.request.session.email` is also no longer valid. Therefore, we now attach the socket to the user when we authenticate the access token/API key provided.

This fixes socket issues, such as `classUpdate` not being sent out properly.