### PR TITLE
Add backwards compatibilty for auxiliary apps

### DIFF
--- a/api/v1/controllers/auth/google.js
+++ b/api/v1/controllers/auth/google.js
@@ -17,9 +17,18 @@ function checkEnabled(req, res, next) {
 
 module.exports = (router) => {
     // Initiate Google OAuth flow
+    // Accepts an optional `origin` query parameter which is stored in the session
+    // so the callback can redirect the browser back to the SPA with tokens.
     router.get(
         "/auth/google",
         checkEnabled,
+        (req, res, next) => {
+            // Persist the caller's origin so the callback can redirect back
+            if (req.query.origin) {
+                req.session.oauthOrigin = String(req.query.origin);
+            }
+            next();
+        },
         passport.authenticate("google", {
             scope: ["profile", "email"],
             session: false,
@@ -109,6 +118,20 @@ module.exports = (router) => {
                 );
             }
 
+            // If the request came from the SPA via a browser redirect (origin stored
+            // in session), redirect back to the client login page with the tokens so
+            // the SPA can complete the login flow without an extra round-trip.
+            const clientOrigin = req.session?.oauthOrigin;
+            if (clientOrigin) {
+                delete req.session.oauthOrigin;
+                req.infoEvent("auth.google.callback.redirect", "Redirecting to SPA after Google OAuth");
+                const redirect = new URL(clientOrigin);
+                redirect.searchParams.set("accessToken", result.tokens.accessToken);
+                redirect.searchParams.set("refreshToken", result.tokens.refreshToken);
+                return res.redirect(redirect.toString());
+            }
+
+            // Fallback for direct API consumers: return tokens as JSON
             res.json({
                 success: true,
                 data: {

--- a/api/v1/controllers/auth/google.js
+++ b/api/v1/controllers/auth/google.js
@@ -126,8 +126,13 @@ module.exports = (router) => {
                 delete req.session.oauthOrigin;
                 req.infoEvent("auth.google.callback.redirect", "Redirecting to SPA after Google OAuth");
                 const redirect = new URL(clientOrigin);
-                redirect.searchParams.set("accessToken", result.tokens.accessToken);
-                redirect.searchParams.set("refreshToken", result.tokens.refreshToken);
+                // Place tokens in the URL fragment instead of query parameters to
+                // avoid leaking them via Referer headers and intermediary logs.
+                const existingHash = redirect.hash ? redirect.hash.replace(/^#/, "") : "";
+                const hashParams = new URLSearchParams(existingHash);
+                hashParams.set("accessToken", tokens.accessToken);
+                hashParams.set("refreshToken", tokens.refreshToken);
+                redirect.hash = hashParams.toString();
                 return res.redirect(redirect.toString());
             }
 

--- a/app.js
+++ b/app.js
@@ -157,6 +157,24 @@ function getJSFiles(dir, base = dir) {
     return results;
 }
 
+const LEGACY_API_WARNING =
+    '299 - "Deprecated API: Non-versioned /api endpoints are deprecated. Use /api/v1 endpoints instead. This compatibility layer will be removed in a future version."';
+
+function attachLegacyApiDeprecationHeaders(req, res, next) {
+    res.setHeader("X-Deprecated", "Use /api/v1 endpoints instead");
+    res.setHeader("Deprecation", "true");
+    res.setHeader("Sunset", "Tue, 01 Sep 2026 00:00:00 GMT");
+    res.append("Warning", LEGACY_API_WARNING);
+    next();
+}
+
+// This is hacky but it works, I suppose.
+function rewriteLegacyApiPaths(req, res, next) {
+    req.url = req.url.replace(/^\/me(?=\/|$|\?)/, "/user/me");
+    req.url = req.url.replace(/^\/user\/([^/]+)\/ownedClasses(?=\/|$|\?)/, "/user/$1/classes");
+    next();
+}
+
 // Import API routes
 const apiVersionFolders = fs.readdirSync("./api");
 for (const apiVersionFolder of apiVersionFolders) {
@@ -183,6 +201,18 @@ for (const apiVersionFolder of apiVersionFolders) {
         }
 
         app.use(`/api/${apiVersionFolder}`, router);
+
+        // Backwards compatibility for legacy non-versioned API paths.
+        if (apiVersionFolder === "v1") {
+            app.use("/api", (req, res, next) => {
+                // Keep /api/v{n} requests exclusively on their versioned mounts.
+                if (/^\/v\d+(?:\/|$)/.test(req.path)) return next();
+
+                attachLegacyApiDeprecationHeaders(req, res, () => {
+                    rewriteLegacyApiPaths(req, res, () => router(req, res, next));
+                });
+            });
+        }
     }
 }
 

--- a/middleware/rate-limiter.js
+++ b/middleware/rate-limiter.js
@@ -70,12 +70,14 @@ async function rateLimiter(req, res, next) {
                 limit,
                 permissions: user.permissions,
             });
-            return res.status(429).json({ error: `You are being rate limited. Please try again in ${timeFrame / 1000} seconds.` });
         }
-    } else {
-        userRequests[path].push(currentTime);
-        next();
+
+        // Always respond while over-limit; otherwise the request hangs forever.
+        return res.status(429).json({ error: `You are being rate limited. Please try again in ${timeFrame / 1000} seconds.` });
     }
+
+    userRequests[path].push(currentTime);
+    next();
 }
 
 module.exports = {

--- a/services/auth-service.js
+++ b/services/auth-service.js
@@ -128,6 +128,11 @@ async function login(email, password) {
         const tokens = generateAuthTokens(userData);
         const decodedRefreshToken = jwt.decode(tokens.refreshToken);
         const tokenHash = hashToken(tokens.refreshToken);
+
+        // Delete any existing auth refresh tokens for this user before inserting.
+        // Without this, rapid successive logins within the same second produce
+        // identical JWTs (second-precision iat) → identical hashes → UNIQUE violation.
+        await dbRun("DELETE FROM refresh_tokens WHERE user_id = ? AND token_type = 'auth'", [userData.id]);
         await dbRun("INSERT INTO refresh_tokens (user_id, token_hash, exp, token_type) VALUES (?, ?, ?, ?)", [
             userData.id,
             tokenHash,
@@ -135,7 +140,11 @@ async function login(email, password) {
             "auth",
         ]);
 
-        return { tokens, user: userData };
+        // Generate a legacy OAuth token (includes permissions) for backwards-compatible
+        // third-party apps (e.g. Jukebar) that use the /oauth redirect flow.
+        const legacyToken = generateLegacyOAuthToken(userData);
+
+        return { tokens: { ...tokens, legacyToken }, user: userData };
     } else {
         return invalidCredentials();
     }
@@ -215,7 +224,34 @@ function generateAuthTokens(userData) {
  * @returns {string} A JWT refresh token valid for 30 days
  */
 function generateRefreshToken(userData) {
-    return jwt.sign({ id: userData.id }, privateKey, { algorithm: "RS256", expiresIn: "30d" });
+    return jwt.sign({ id: userData.id, jti: crypto.randomBytes(16).toString("hex") }, privateKey, { algorithm: "RS256", expiresIn: "30d" });
+}
+
+/**
+ * Generates a legacy OAuth token for backwards-compatible third-party apps (e.g. Jukebar).
+ *
+ * Includes `permissions` in the payload because legacy clients read that field directly
+ * from the decoded JWT.  The token is still signed with RS256 so that the
+ * backwards-compat socket handler can verify it with `verifyToken()`.
+ *
+ * @param {Object} userData - The user data object
+ * @param {number} userData.id - The user's unique identifier
+ * @param {string} userData.email - The user's email address
+ * @param {string} userData.displayName - The user's display name
+ * @param {number} userData.permissions - The user's permission level
+ * @returns {string} A signed JWT valid for 1 hour
+ */
+function generateLegacyOAuthToken(userData) {
+    return jwt.sign(
+        {
+            id: userData.id,
+            email: userData.email,
+            displayName: userData.displayName,
+            permissions: userData.permissions,
+        },
+        privateKey,
+        { algorithm: "RS256", expiresIn: "1h" }
+    );
 }
 
 /**
@@ -499,4 +535,5 @@ module.exports = {
     revokeOAuthToken,
     cleanupExpiredAuthorizationCodes,
     hashToken,
+    generateLegacyOAuthToken,
 };

--- a/services/auth-service.js
+++ b/services/auth-service.js
@@ -129,10 +129,8 @@ async function login(email, password) {
         const decodedRefreshToken = jwt.decode(tokens.refreshToken);
         const tokenHash = hashToken(tokens.refreshToken);
 
-        // Delete any existing auth refresh tokens for this user before inserting.
-        // Without this, rapid successive logins within the same second produce
-        // identical JWTs (second-precision iat) → identical hashes → UNIQUE violation.
-        await dbRun("DELETE FROM refresh_tokens WHERE user_id = ? AND token_type = 'auth'", [userData.id]);
+        // Each refresh token includes a random `jti` so tokens generated in the
+        // same second will have different hashes and won't collide.
         await dbRun("INSERT INTO refresh_tokens (user_id, token_hash, exp, token_type) VALUES (?, ?, ?, ?)", [
             userData.id,
             tokenHash,

--- a/services/digipog-service.js
+++ b/services/digipog-service.js
@@ -313,6 +313,14 @@ async function transferDigipogs(transferData) {
             return { success: false, message: "Missing sender identifier." };
         }
         if (!from.type) from.type = "user";
+        // Normalize `to` independently: if it's still a primitive at this point
+        // (e.g. the caller passed an object `from` but a raw id for `to`), wrap it
+        // rather than letting `to.type` throw on a non-object.
+        if (typeof to === "string" || typeof to === "number") {
+            to = { id: to, type: pool ? "pool" : "user" };
+        } else if (!to || typeof to !== "object") {
+            return { success: false, message: "Missing recipient identifier." };
+        }
         if (!to.type) to.type = "user";
 
         if (!from || !from.id || !to || !to.id || !amount || reason === undefined || !pin) {

--- a/services/digipog-service.js
+++ b/services/digipog-service.js
@@ -163,19 +163,17 @@ async function getUserTransactions(userId) {
 async function awardDigipogs(awardData, user) {
     try {
         const from = user.userId;
-        const to = awardData.to;
         const amount = Math.ceil(awardData.amount);
         const reason = awardData.reason || "Awarded";
 
+        let to = awardData.to;
         let deprecatedFormatUsed = false;
-        if (!to.id && !to.code) {
-            if (typeof to === "string" || typeof to === "number") {
-                to.id = to;
-                to.type = "user";
-            } else {
-                return { success: false, message: "Missing recipient identifier." };
-            }
+        if (typeof to === "string" || typeof to === "number") {
+            // Old API: `to` was a plain user ID — normalize to new object format
+            to = { id: to, type: "user" };
             deprecatedFormatUsed = true;
+        } else if (!to || (!to.id && !to.code)) {
+            return { success: false, message: "Missing recipient identifier." };
         }
 
         if (!from || !to || !amount) {
@@ -297,24 +295,22 @@ async function awardDigipogs(awardData, user) {
 
 async function transferDigipogs(transferData) {
     try {
-        const { from, to, pin, reason = "", pool } = transferData;
+        const { pin, reason = "", pool } = transferData;
+        let from = transferData.from;
+        let to = transferData.to;
         const amount = Math.floor(transferData.amount);
 
         let deprecatedFormatUsed = false;
-        if (!from.id) {
-            if (typeof from === "string" || typeof from === "number") {
-                from.id = from;
-                from.type = "user";
-            } else {
-                return { success: false, message: "Missing sender identifier." };
-            }
-            if (typeof to === "string" || typeof to === "number") {
-                to.id = pool ? pool : to;
-                to.type = pool ? "pool" : "user";
-            } else {
+        if (typeof from === "string" || typeof from === "number") {
+            // Old API: `from`/`to` were plain user IDs; `pool` flag indicated a pool recipient
+            if (typeof to !== "string" && typeof to !== "number") {
                 return { success: false, message: "Missing recipient identifier." };
             }
+            from = { id: from, type: "user" };
+            to = { id: pool ? pool : to, type: pool ? "pool" : "user" };
             deprecatedFormatUsed = true;
+        } else if (!from || !from.id) {
+            return { success: false, message: "Missing sender identifier." };
         }
         if (!from.type) from.type = "user";
         if (!to.type) to.type = "user";

--- a/sockets/backwards-compat.js
+++ b/sockets/backwards-compat.js
@@ -36,8 +36,9 @@ module.exports = {
                     return socket.emit("error", "Invalid API key format.");
                 }
 
-                // Find the user whose hashed API key matches the provided plaintext key
-                const users = await dbGetAll("SELECT * FROM users");
+                // Find the user whose hashed API key matches the provided plaintext key.
+                // Limit to users with an API key set and only fetch needed columns.
+                const users = await dbGetAll("SELECT id, email, API, permissions, tags, displayName FROM users WHERE API IS NOT NULL");
                 let userData = null;
                 for (const user of users) {
                     if (user.API && (await compare(apiKey, user.API))) {

--- a/sockets/backwards-compat.js
+++ b/sockets/backwards-compat.js
@@ -13,8 +13,7 @@ const { handleSocketError } = require("@modules/socket-error-handler");
 const { finalizeAuthentication } = require("./middleware/api");
 
 const DEPRECATION_NOTICE =
-    "Deprecated authentication method used. Please update to use header-based authentication. " +
-    "See the Formbar.js API documentation for details.";
+    "Deprecated authentication method used. Please update to use header-based authentication. " + "See the Formbar.js API documentation for details.";
 
 module.exports = {
     run(socket, socketUpdates) {

--- a/sockets/backwards-compat.js
+++ b/sockets/backwards-compat.js
@@ -1,0 +1,129 @@
+/**
+ * Backwards Compatibility Socket Handlers
+ *
+ * Supports auxiliary applications built against the old Formbar API.
+ * Each handler normalizes the legacy call pattern to the current API, and
+ * emits a deprecation warning so developers know to migrate.
+ */
+
+const { dbGetAll, dbGet } = require("@modules/database");
+const { compare } = require("@modules/crypto");
+const { verifyToken } = require("@services/auth-service");
+const { handleSocketError } = require("@modules/socket-error-handler");
+const { finalizeAuthentication } = require("./middleware/api");
+
+const DEPRECATION_NOTICE =
+    "Deprecated authentication method used. Please update to use header-based authentication. " +
+    "See the Formbar.js API documentation for details.";
+
+module.exports = {
+    run(socket, socketUpdates) {
+        /**
+         * formPix backwards compatibility.
+         *
+         * Old behaviour: the client emits `getActiveClass` with a raw API key string;
+         *   the server responds with `setClass`.
+         * New behaviour: pass the API key in the `api` request header when connecting.
+         */
+        socket.on("getActiveClass", async (apiKey) => {
+            try {
+                // Already authenticated — just echo back the current class
+                if (socket.request.session.email) {
+                    socket.emit("setClass", socket.request.session.classId);
+                    return;
+                }
+
+                if (typeof apiKey !== "string" || !apiKey) {
+                    return socket.emit("error", "Invalid API key format.");
+                }
+
+                // Find the user whose hashed API key matches the provided plaintext key
+                const users = await dbGetAll("SELECT * FROM users");
+                let userData = null;
+                for (const user of users) {
+                    if (user.API && (await compare(apiKey, user.API))) {
+                        userData = user;
+                        break;
+                    }
+                }
+
+                if (!userData) {
+                    return socket.emit("error", "Invalid API key.");
+                }
+
+                finalizeAuthentication(socket, userData, socketUpdates, true);
+
+                socket.emit("deprecationWarning", {
+                    message: DEPRECATION_NOTICE,
+                    event: "getActiveClass",
+                    recommendation: "Pass your API key in the `api` request header when connecting to the socket.",
+                });
+            } catch (err) {
+                handleSocketError(err, socket, "getActiveClass");
+            }
+        });
+
+        /**
+         * jukebar backwards compatibility.
+         *
+         * Old behaviour: the client emits `auth` with `{ token: <JWT> }`; the server
+         *   responds with `setClass`.
+         * New behaviour: pass the access token in the `authorization` request header when connecting.
+         */
+        socket.on("auth", async (data) => {
+            try {
+                // Already authenticated — just echo back the current class
+                if (socket.request.session.email) {
+                    socket.emit("setClass", socket.request.session.classId);
+                    return;
+                }
+
+                const token = data && data.token;
+                if (!token || typeof token !== "string") {
+                    return socket.emit("error", "Missing or invalid authentication token.");
+                }
+
+                const decodedToken = verifyToken(token);
+                if (decodedToken.error) {
+                    return socket.emit("error", "Invalid access token.");
+                }
+
+                const { email, id: userId } = decodedToken;
+                if (!email || !userId) {
+                    return socket.emit("error", "Invalid access token: missing required fields.");
+                }
+
+                const userData = await dbGet("SELECT * FROM users WHERE id = ?", [userId]);
+                if (!userData) {
+                    return socket.emit("error", "User not found.");
+                }
+
+                finalizeAuthentication(socket, userData, socketUpdates, false);
+
+                socket.emit("deprecationWarning", {
+                    message: DEPRECATION_NOTICE,
+                    event: "auth",
+                    recommendation: "Pass your access token in the `authorization` request header when connecting to the socket.",
+                });
+            } catch (err) {
+                handleSocketError(err, socket, "auth");
+            }
+        });
+
+        /**
+         * General backwards compatibility (formPix + jukebar).
+         *
+         * Old behaviour: the client emits `getClassroom` to request the current classroom
+         *   state; the server responds with a `classUpdate` event.
+         * New behaviour: the server automatically emits `classUpdate` whenever the class
+         *   state changes, but `getClassroom` is still supported for an explicit pull.
+         */
+        socket.on("getClassroom", () => {
+            try {
+                socketUpdates.classUpdate(socket.request.session.classId, { global: false });
+            } catch (err) {
+                handleSocketError(err, socket, "getClassroom");
+            }
+        });
+    },
+};

--- a/sockets/middleware/api.js
+++ b/sockets/middleware/api.js
@@ -49,12 +49,15 @@ function setupSocketSession(socket, userData, includeApi = false) {
  * Joins socket to appropriate rooms based on authentication type.
  */
 function joinSocketRooms(socket, email, classId, isApiAuth = false) {
+    // Always join the personal room so future setClassOfApiSockets / setClassOfUserSockets
+    // calls can locate this socket even when no class is active yet.
+    if (isApiAuth) {
+        socket.join(`api-${socket.request.session.api}`);
+    } else {
+        socket.join(`user-${email}`);
+    }
+
     if (classId) {
-        if (isApiAuth) {
-            socket.join(`api-${socket.request.session.api}`);
-        } else {
-            socket.join(`user-${email}`);
-        }
         socket.join(`class-${classId}`);
     }
 }
@@ -80,7 +83,15 @@ function setupDisconnectHandler(socket, email, classId, isApiAuth = false) {
             }
         } else {
             const { emptyAfterRemoval } = socketStateStore.removeUserSocket(email, socket.id);
-            if (emptyAfterRemoval) classKickStudent(userId, classId, false);
+            if (emptyAfterRemoval) {
+                // Give the client a short grace period (5 minutes) to reconnect
+                // before treating the disconnect as a deliberate class leave.
+                setTimeout(async () => {
+                    if (!socketStateStore.hasUserSockets(email)) {
+                        classKickStudent(userId, classId, false);
+                    }
+                }, 300000);
+            }
         }
     });
 }
@@ -107,6 +118,8 @@ function finalizeAuthentication(socket, userData, socketUpdates, isApiAuth = fal
 
 module.exports = {
     order: 10,
+    // Exported for use in backwards-compat.js to authenticate sockets via legacy socket events
+    finalizeAuthentication,
     async run(socket, socketUpdates) {
         try {
             const { api, authorization } = socket.request.headers;

--- a/sockets/middleware/api.js
+++ b/sockets/middleware/api.js
@@ -11,6 +11,13 @@ const { addUserSocketUpdate, removeUserSocketUpdate } = require("../init");
 const { handleSocketError } = require("@modules/socket-error-handler");
 
 /**
+ * Tracks per-user reconnect grace-period timer handles.
+ * Keyed by email; cleared whenever the user reconnects so stale timers
+ * cannot fire and kick a user who has already re-established a socket.
+ */
+const reconnectTimers = new Map();
+
+/**
  * Ensures a Student instance exists in classStateStore for the given user.
  * Creates a new Student object if one doesn't already exist for the user's email.
  */
@@ -79,18 +86,21 @@ function setupDisconnectHandler(socket, email, classId, isApiAuth = false) {
         const userId = await getIdFromEmail(email);
         if (isApiAuth) {
             if (!socketStateStore.hasUserSockets(email)) {
-                classKickStudent(userId, classId, false);
+                classKickStudent(userId, classId, { exitRoom: false, ban: false });
             }
         } else {
             const { emptyAfterRemoval } = socketStateStore.removeUserSocket(email, socket.id);
             if (emptyAfterRemoval) {
                 // Give the client a short grace period (5 minutes) to reconnect
                 // before treating the disconnect as a deliberate class leave.
-                setTimeout(async () => {
+                // Store the handle so a later reconnect can cancel it.
+                const timer = setTimeout(async () => {
+                    reconnectTimers.delete(email);
                     if (!socketStateStore.hasUserSockets(email)) {
-                        classKickStudent(userId, classId, false);
+                        classKickStudent(userId, classId, { exitRoom: false, ban: false });
                     }
                 }, 300000);
+                reconnectTimers.set(email, timer);
             }
         }
     });
@@ -104,6 +114,13 @@ function finalizeAuthentication(socket, userData, socketUpdates, isApiAuth = fal
     setupSocketSession(socket, userData, isApiAuth);
 
     const { email, classId } = socket.request.session;
+
+    // Cancel any pending reconnect-kick timer so a reconnecting user isn't
+    // evicted by a timer that was started during their previous disconnect.
+    if (reconnectTimers.has(email)) {
+        clearTimeout(reconnectTimers.get(email));
+        reconnectTimers.delete(email);
+    }
 
     joinSocketRooms(socket, email, classId, isApiAuth);
     socket.emit("setClass", classId);
@@ -127,8 +144,10 @@ module.exports = {
             // Try API key authentication first
             if (api) {
                 await new Promise((resolve, reject) => {
-                    // Look up the user by comparing API key hash
-                    database.all("SELECT * FROM users", [], async (err, users) => {
+                    // Look up the user by comparing API key hash.
+                    // Only fetch users that actually have an API key set to avoid
+                    // pulling sensitive columns (password hash, secret) for every user.
+                    database.all("SELECT id, email, API, permissions, tags, displayName FROM users WHERE API IS NOT NULL", [], async (err, users) => {
                         try {
                             if (err) throw err;
 

--- a/sockets/middleware/authentication.js
+++ b/sockets/middleware/authentication.js
@@ -5,6 +5,10 @@ const authService = require("@services/auth-service");
 
 const { handleSocketError } = require("@modules/socket-error-handler");
 
+// Legacy bootstrap events that must be allowed through before a session is
+// established — they ARE the authentication mechanism for old API clients.
+const LEGACY_AUTH_EVENTS = new Set(["getActiveClass", "auth"]);
+
 module.exports = {
     order: 20,
     run(socket, socketUpdates) {
@@ -12,6 +16,14 @@ module.exports = {
         // The user must be logged in order to connect to websockets
         socket.use(([event, ...args], next) => {
             try {
+                // Allow legacy backwards-compat events to reach their handlers
+                // so those handlers can establish a session before this middleware
+                // would otherwise reject them.
+                if (LEGACY_AUTH_EVENTS.has(event)) {
+                    next();
+                    return;
+                }
+
                 let { api, authorization } = socket.request.headers;
 
                 if (socket.request.session.email) {

--- a/sockets/middleware/authentication.js
+++ b/sockets/middleware/authentication.js
@@ -76,8 +76,6 @@ module.exports = {
                             next(err);
                         }
                     });
-                } else if (event == "reload") {
-                    next();
                 } else {
                     next(new Error("Missing authentication credentials"));
                 }


### PR DESCRIPTION
This PR attempts to solve #944 by implementing backwards compatibility for old HTTP and socket APIs.
Legacy HTTP APIs are mapped to the newer APIs.
Socket APIs have handling that keeps them *mostly* compatible with old auxiliary apps.