### PR TITLE
Fix performance issues with pins and API keys

### DIFF
--- a/api/v1/controllers/class/kick.js
+++ b/api/v1/controllers/class/kick.js
@@ -86,7 +86,6 @@ module.exports = (router) => {
      *       - Class
      *     description: |
      *       Removes all students in the class who do not have teacher-level permissions.
-     *       The `userId` path parameter is accepted for compatibility and is ignored by this operation.
      *
      *       **Required scope:** `class.students.kick`
      *     security:
@@ -99,12 +98,6 @@ module.exports = (router) => {
      *         schema:
      *           type: string
      *         description: Class ID
-     *       - in: path
-     *         name: userId
-     *         required: true
-     *         schema:
-     *           type: string
-     *         description: Placeholder user ID (ignored)
      *     responses:
      *       200:
      *         description: Students were kicked successfully
@@ -127,19 +120,15 @@ module.exports = (router) => {
      */
     router.post("/class/:id/students/kick-all", isAuthenticated, hasClassScope(SCOPES.CLASS.STUDENTS.KICK), async (req, res) => {
         const classId = Number(req.params.id);
-        const targetUserId = req.params.userId !== undefined ? Number(req.params.userId) : undefined;
 
         requireQueryParam(classId, "id");
-        if (req.params.userId !== undefined) {
-            requireQueryParam(targetUserId, "userId");
-        }
 
-        req.infoEvent("class.kick.all.attempt", "Attempting to kick all eligible students from class", { classId, targetUserId });
+        req.infoEvent("class.kick.all.attempt", "Attempting to kick all eligible students from class", { classId });
 
         await classKickStudents(classId);
         await advancedEmitToClass("kickStudentsSound", classId, { api: true });
 
-        req.infoEvent("class.kick.all.success", "Kicked all students from class", { classId, targetUserId });
+        req.infoEvent("class.kick.all.success", "Kicked all students from class", { classId });
         res.status(200).json({
             success: true,
             data: {},

--- a/api/v1/controllers/class/kick.js
+++ b/api/v1/controllers/class/kick.js
@@ -78,35 +78,8 @@ module.exports = (router) => {
     });
 
     /**
-     * * Handle the kick all students request.
-     * @param {import("express").Request} req - req.
-     * @param {import("express").Response} res - res.
-     * @returns {Promise<void>}
-     */
-    const kickAllStudentsHandler = async (req, res) => {
-        const classId = Number(req.params.id);
-        const targetUserId = req.params.userId !== undefined ? Number(req.params.userId) : undefined;
-
-        requireQueryParam(classId, "id");
-        if (req.params.userId !== undefined) {
-            requireQueryParam(targetUserId, "userId");
-        }
-
-        req.infoEvent("class.kick.all.attempt", "Attempting to kick all eligible students from class", { classId, targetUserId });
-
-        await classKickStudents(classId);
-        await advancedEmitToClass("kickStudentsSound", classId, { api: true });
-
-        req.infoEvent("class.kick.all.success", "Kicked all students from class", { classId, targetUserId });
-        res.status(200).json({
-            success: true,
-            data: {},
-        });
-    };
-
-    /**
      * @swagger
-     * /api/v1/class/{id}/students/{userId}/kick-all:
+     * /api/v1/class/{id}/students/kick-all:
      *   post:
      *     summary: Kick all students from a class
      *     tags:
@@ -152,6 +125,24 @@ module.exports = (router) => {
      *             schema:
      *               $ref: '#/components/schemas/Error'
      */
-    router.post("/class/:id/students/:userId/kick-all", isAuthenticated, hasClassScope(SCOPES.CLASS.STUDENTS.KICK), kickAllStudentsHandler);
-    router.post("/class/:id/students/kick-all", isAuthenticated, hasClassScope(SCOPES.CLASS.STUDENTS.KICK), kickAllStudentsHandler);
+    router.post("/class/:id/students/kick-all", isAuthenticated, hasClassScope(SCOPES.CLASS.STUDENTS.KICK), async (req, res) => {
+        const classId = Number(req.params.id);
+        const targetUserId = req.params.userId !== undefined ? Number(req.params.userId) : undefined;
+
+        requireQueryParam(classId, "id");
+        if (req.params.userId !== undefined) {
+            requireQueryParam(targetUserId, "userId");
+        }
+
+        req.infoEvent("class.kick.all.attempt", "Attempting to kick all eligible students from class", { classId, targetUserId });
+
+        await classKickStudents(classId);
+        await advancedEmitToClass("kickStudentsSound", classId, { api: true });
+
+        req.infoEvent("class.kick.all.success", "Kicked all students from class", { classId, targetUserId });
+        res.status(200).json({
+            success: true,
+            data: {},
+        });
+    });
 };

--- a/api/v1/controllers/digipogs/transfer.js
+++ b/api/v1/controllers/digipogs/transfer.js
@@ -3,6 +3,27 @@ const { hasScope } = require("@middleware/permission-check");
 const { SCOPES } = require("@modules/permissions");
 const AppError = require("@errors/app-error");
 
+function normalizeTransferFrom(rawFrom) {
+    if (rawFrom === undefined || rawFrom === null || rawFrom === "") {
+        return null;
+    }
+
+    if (typeof rawFrom === "object") {
+        const type = rawFrom.type || "user";
+        const id = Number(rawFrom.id ?? rawFrom.userId ?? rawFrom.poolId);
+        if (!Number.isInteger(id) || id <= 0 || !["user", "pool"].includes(type)) {
+            return null;
+        }
+        return { id, type };
+    }
+
+    const id = Number(rawFrom);
+    if (!Number.isInteger(id) || id <= 0) {
+        return null;
+    }
+    return { id, type: "user" };
+}
+
 /**
  * * Register transfer controller routes.
  * @param {import("express").Router} router - router.
@@ -30,10 +51,17 @@ module.exports = (router) => {
      *           schema:
      *             type: object
      *             required:
+     *               - from
      *               - to
      *               - amount
      *               - pin
      *             properties:
+     *               from:
+     *                 oneOf:
+     *                   - type: integer
+     *                   - type: object
+     *                 example: 1
+     *                 description: Sender account. Required with PIN transfers so the PIN can be checked with a targeted lookup.
      *               to:
      *                 type: string
      *                 example: "user123"
@@ -81,19 +109,36 @@ module.exports = (router) => {
      *               $ref: '#/components/schemas/ServerError'
      */
     router.post("/digipogs/transfer", hasScope(SCOPES.GLOBAL.DIGIPOGS.TRANSFER), async (req, res) => {
-        const { to, amount, pin, reason } = req.body || {};
+        const { from: rawFrom, to, amount, pin, reason, pool } = req.body || {};
+        const requestedFrom = normalizeTransferFrom(rawFrom);
 
-        // Derive the authenticated user ID from the server-side context, not from client input
-        const from = req.user?.id || req.user?.userId;
+        if (!requestedFrom) {
+            throw new AppError("Missing sender identifier.", {
+                statusCode: 400,
+                event: "digipogs.transfer.failed",
+                reason: "missing_sender",
+            });
+        }
 
-        if (!from) {
-            throw new AppError({
+        const authenticatedUserId = req.user?.id || req.user?.userId;
+
+        if (!authenticatedUserId) {
+            throw new AppError("Unable to determine authenticated user for digipogs transfer.", {
                 statusCode: 401,
-                message: "Unable to determine authenticated user for digipogs transfer.",
                 event: "digipogs.transfer.failed",
                 reason: "user_not_found",
             });
         }
+
+        if (!req.pinAuthenticatedFrom && requestedFrom.type === "user" && requestedFrom.id !== authenticatedUserId) {
+            throw new AppError("Sender identifier does not match the authenticated user.", {
+                statusCode: 403,
+                event: "digipogs.transfer.failed",
+                reason: "sender_mismatch",
+            });
+        }
+
+        const from = req.pinAuthenticatedFrom || (requestedFrom.type === "pool" ? requestedFrom : { id: authenticatedUserId, type: "user" });
 
         req.infoEvent("digipogs.transfer.attempt", "Attempting to transfer digipogs", { from, to, amount });
 
@@ -102,6 +147,7 @@ module.exports = (router) => {
             to,
             amount,
             pin,
+            ...(pool !== undefined && { pool }),
             ...(reason !== undefined && { reason }),
         };
 

--- a/api/v1/controllers/digipogs/transfer.js
+++ b/api/v1/controllers/digipogs/transfer.js
@@ -1,28 +1,6 @@
 const { transferDigipogs } = require("@services/digipog-service");
-const { hasScope } = require("@middleware/permission-check");
-const { SCOPES } = require("@modules/permissions");
+const { getTransferFromValue, normalizeTransferFrom } = require("@modules/digipog-transfer");
 const AppError = require("@errors/app-error");
-
-function normalizeTransferFrom(rawFrom) {
-    if (rawFrom === undefined || rawFrom === null || rawFrom === "") {
-        return null;
-    }
-
-    if (typeof rawFrom === "object") {
-        const type = rawFrom.type || "user";
-        const id = Number(rawFrom.id ?? rawFrom.userId ?? rawFrom.poolId);
-        if (!Number.isInteger(id) || id <= 0 || !["user", "pool"].includes(type)) {
-            return null;
-        }
-        return { id, type };
-    }
-
-    const id = Number(rawFrom);
-    if (!Number.isInteger(id) || id <= 0) {
-        return null;
-    }
-    return { id, type: "user" };
-}
 
 /**
  * * Register transfer controller routes.
@@ -40,10 +18,6 @@ module.exports = (router) => {
      *     description: |
      *       Transfers digipogs from your account to another user.
      *
-     *       **Required Scope:** `global.digipogs.transfer` (granted to Student role and above)
-     *     security:
-     *       - bearerAuth: []
-     *       - apiKeyAuth: []
      *     requestBody:
      *       required: true
      *       content:
@@ -61,7 +35,7 @@ module.exports = (router) => {
      *                   - type: integer
      *                   - type: object
      *                 example: 1
-     *                 description: Sender account. Required with PIN transfers so the PIN can be checked with a targeted lookup.
+     *                 description: Sender account. The PIN is validated against this sender.
      *               to:
      *                 type: string
      *                 example: "user123"
@@ -95,12 +69,6 @@ module.exports = (router) => {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/Error'
-     *       401:
-     *         description: Not authenticated
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/UnauthorizedError'
      *       500:
      *         description: Transfer failed
      *         content:
@@ -108,9 +76,9 @@ module.exports = (router) => {
      *             schema:
      *               $ref: '#/components/schemas/ServerError'
      */
-    router.post("/digipogs/transfer", hasScope(SCOPES.GLOBAL.DIGIPOGS.TRANSFER), async (req, res) => {
-        const { from: rawFrom, to, amount, pin, reason, pool } = req.body || {};
-        const requestedFrom = normalizeTransferFrom(rawFrom);
+    router.post("/digipogs/transfer", async (req, res) => {
+        const body = req.body || {};
+        const requestedFrom = normalizeTransferFrom(getTransferFromValue(body));
 
         if (!requestedFrom) {
             throw new AppError("Missing sender identifier.", {
@@ -120,43 +88,27 @@ module.exports = (router) => {
             });
         }
 
-        const authenticatedUserId = req.user?.id || req.user?.userId;
-
-        if (!authenticatedUserId) {
-            throw new AppError("Unable to determine authenticated user for digipogs transfer.", {
-                statusCode: 401,
-                event: "digipogs.transfer.failed",
-                reason: "user_not_found",
-            });
-        }
-
-        if (!req.pinAuthenticatedFrom && requestedFrom.type === "user" && requestedFrom.id !== authenticatedUserId) {
-            throw new AppError("Sender identifier does not match the authenticated user.", {
-                statusCode: 403,
-                event: "digipogs.transfer.failed",
-                reason: "sender_mismatch",
-            });
-        }
-
-        const from = req.pinAuthenticatedFrom || (requestedFrom.type === "pool" ? requestedFrom : { id: authenticatedUserId, type: "user" });
-
-        req.infoEvent("digipogs.transfer.attempt", "Attempting to transfer digipogs", { from, to, amount });
-
         const transferPayload = {
-            from,
-            to,
-            amount,
-            pin,
-            ...(pool !== undefined && { pool }),
-            ...(reason !== undefined && { reason }),
+            ...body,
+            from: requestedFrom,
         };
+
+        req.infoEvent("digipogs.transfer.attempt", "Attempting to transfer digipogs", {
+            from: transferPayload.from,
+            to: transferPayload.to,
+            amount: transferPayload.amount,
+        });
 
         const result = await transferDigipogs(transferPayload);
         if (!result.success) {
             throw new AppError(result.message, { statusCode: 400, event: "digipogs.transfer.failed", reason: "transfer_error" });
         }
 
-        req.infoEvent("digipogs.transfer.success", "Digipogs transferred successfully", { from, to, amount });
+        req.infoEvent("digipogs.transfer.success", "Digipogs transferred successfully", {
+            from: transferPayload.from,
+            to: transferPayload.to,
+            amount: transferPayload.amount,
+        });
         res.status(200).json({
             success: true,
             data: result,

--- a/api/v1/controllers/tests/class.spec.js
+++ b/api/v1/controllers/tests/class.spec.js
@@ -940,23 +940,6 @@ describe("POST /api/v1/class/:id/students/kick-all", () => {
         expect(res.status).toBe(401);
     });
 
-    it("supports the compatibility route with userId in the path", async () => {
-        const { tokens: teacherTokens, user: teacher } = await seedAuthenticatedUser(mockDatabase, {
-            email: "teacher-kickall-compat@example.com",
-            displayName: "KickCompat",
-            permissions: TEACHER_PERMISSIONS,
-        });
-        const classId = await seedClassroom(teacher.id, { key: "KALC1", className: "Kick All Compat Test" });
-        await enrollUserInClass(teacher, classId, TEACHER_PERMISSIONS);
-
-        const res = await request(app)
-            .post(`/api/v1/class/${classId}/students/${teacher.id}/kick-all`)
-            .set("Authorization", `Bearer ${teacherTokens.accessToken}`);
-
-        expect(res.status).toBe(200);
-        expect(res.body.success).toBe(true);
-    });
-
     it("kicks only users without teacher-related scopes", async () => {
         const { tokens: teacherTokens, user: teacher } = await seedAuthenticatedUser(mockDatabase, {
             email: "teacher-kickall@example.com",

--- a/api/v1/controllers/tests/config.spec.js
+++ b/api/v1/controllers/tests/config.spec.js
@@ -105,13 +105,15 @@ describe("GET /api/v1/certs", () => {
 
         // Ensure the logger mock includes close() so the error handler doesn't crash
         const { getLogger } = require("@modules/logger");
-        getLogger.mockResolvedValue({
+        const logger = {
             log: jest.fn(),
             info: jest.fn(),
             error: jest.fn(),
             warn: jest.fn(),
             close: jest.fn(),
-        });
+        };
+        logger.child = jest.fn(() => logger);
+        getLogger.mockResolvedValue(logger);
 
         jest.spyOn(fs, "readFileSync").mockImplementation(() => {
             throw new Error("ENOENT: no such file or directory");

--- a/api/v1/controllers/tests/digipogs.spec.js
+++ b/api/v1/controllers/tests/digipogs.spec.js
@@ -193,7 +193,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
     });
 
     it("returns 403 for a guest user (permissions=1) who lacks global.digipogs.transfer", async () => {
-        const { tokens } = await seedAuthenticatedUser(mockDatabase, {
+        const { tokens, user } = await seedAuthenticatedUser(mockDatabase, {
             email: "guest@example.com",
             displayName: "Guest",
             permissions: 1,
@@ -202,13 +202,13 @@ describe("POST /api/v1/digipogs/transfer", () => {
         const res = await request(app)
             .post("/api/v1/digipogs/transfer")
             .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ to: "1", amount: 5, pin: "1234" });
+            .send({ from: user.id, to: "1", amount: 5, pin: "1234" });
 
         expect(res.status).toBe(403);
     });
 
     it("returns 403 for a banned user (permissions=0)", async () => {
-        const { tokens } = await seedAuthenticatedUser(mockDatabase, {
+        const { tokens, user } = await seedAuthenticatedUser(mockDatabase, {
             email: "banned@example.com",
             displayName: "Banned",
             permissions: 0,
@@ -217,7 +217,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
         const res = await request(app)
             .post("/api/v1/digipogs/transfer")
             .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ to: "1", amount: 5, pin: "1234" });
+            .send({ from: user.id, to: "1", amount: 5, pin: "1234" });
 
         expect(res.status).toBe(403);
     });
@@ -231,23 +231,23 @@ describe("POST /api/v1/digipogs/transfer", () => {
     });
 
     it("returns 400 when pin is missing", async () => {
-        const { tokens } = await seedAuthenticatedUser(mockDatabase);
+        const { tokens, user } = await seedAuthenticatedUser(mockDatabase);
 
         const res = await request(app)
             .post("/api/v1/digipogs/transfer")
             .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ to: "999", amount: 5 });
+            .send({ from: user.id, to: "999", amount: 5 });
 
         expect(res.status).toBe(400);
     });
 
     it("returns 400 when amount is missing", async () => {
-        const { tokens } = await seedAuthenticatedUser(mockDatabase);
+        const { tokens, user } = await seedAuthenticatedUser(mockDatabase);
 
         const res = await request(app)
             .post("/api/v1/digipogs/transfer")
             .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ to: "999", pin: "1234" });
+            .send({ from: user.id, to: "999", pin: "1234" });
 
         expect(res.status).toBe(400);
     });
@@ -270,7 +270,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
         const res = await request(app)
             .post("/api/v1/digipogs/transfer")
             .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ to: recipient.id, amount: 10, pin: "1234" });
+            .send({ from: sender.id, to: recipient.id, amount: 10, pin: "1234" });
 
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
@@ -278,6 +278,25 @@ describe("POST /api/v1/digipogs/transfer", () => {
         // Verify balances changed
         const senderAfter = await mockDatabase.dbGet("SELECT digipogs FROM users WHERE id = ?", [sender.id]);
         expect(senderAfter.digipogs).toBe(90);
+    });
+
+    it("authenticates a PIN-only transfer by looking up the requested sender", async () => {
+        const { hashBcrypt } = require("@modules/crypto");
+        const pinHash = await hashBcrypt("1234");
+
+        const { user: sender } = await seedAuthenticatedUser(mockDatabase);
+        await mockDatabase.dbRun("UPDATE users SET digipogs = 100, pin = ? WHERE id = ?", [pinHash, sender.id]);
+
+        const { user: recipient } = await seedAuthenticatedUser(mockDatabase, {
+            email: "pin-recipient@example.com",
+            displayName: "PIN Recipient",
+            permissions: 2,
+        });
+
+        const res = await request(app).post("/api/v1/digipogs/transfer").send({ from: sender.id, to: recipient.id, amount: 10, pin: "1234" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
     });
 
     it("returns 400 when the sender has insufficient funds", async () => {
@@ -296,7 +315,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
         const res = await request(app)
             .post("/api/v1/digipogs/transfer")
             .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ to: recipient.id, amount: 50, pin: "1234" });
+            .send({ from: sender.id, to: recipient.id, amount: 50, pin: "1234" });
 
         expect(res.status).toBe(400);
     });
@@ -317,7 +336,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
         const res = await request(app)
             .post("/api/v1/digipogs/transfer")
             .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ to: recipient.id, amount: 10, pin: "wrong" });
+            .send({ from: sender.id, to: recipient.id, amount: 10, pin: "wrong" });
 
         expect(res.status).toBe(400);
     });

--- a/api/v1/controllers/tests/digipogs.spec.js
+++ b/api/v1/controllers/tests/digipogs.spec.js
@@ -253,8 +253,8 @@ describe("POST /api/v1/digipogs/transfer", () => {
     });
 
     it("returns 200 on a valid transfer between two users", async () => {
-        const { hash } = require("@modules/crypto");
-        const pinHash = await hash("1234");
+        const { hashBcrypt } = require("@modules/crypto");
+        const pinHash = await hashBcrypt("1234");
 
         // Seed sender with digipogs and a pin
         const { tokens, user: sender } = await seedAuthenticatedUser(mockDatabase);
@@ -281,8 +281,8 @@ describe("POST /api/v1/digipogs/transfer", () => {
     });
 
     it("returns 400 when the sender has insufficient funds", async () => {
-        const { hash } = require("@modules/crypto");
-        const pinHash = await hash("1234");
+        const { hashBcrypt } = require("@modules/crypto");
+        const pinHash = await hashBcrypt("1234");
 
         const { tokens, user: sender } = await seedAuthenticatedUser(mockDatabase);
         await mockDatabase.dbRun("UPDATE users SET digipogs = 0, pin = ? WHERE id = ?", [pinHash, sender.id]);
@@ -302,8 +302,8 @@ describe("POST /api/v1/digipogs/transfer", () => {
     });
 
     it("returns 400 when the pin is incorrect", async () => {
-        const { hash } = require("@modules/crypto");
-        const pinHash = await hash("1234");
+        const { hashBcrypt } = require("@modules/crypto");
+        const pinHash = await hashBcrypt("1234");
 
         const { tokens, user: sender } = await seedAuthenticatedUser(mockDatabase);
         await mockDatabase.dbRun("UPDATE users SET digipogs = 100, pin = ? WHERE id = ?", [pinHash, sender.id]);
@@ -325,8 +325,8 @@ describe("POST /api/v1/digipogs/transfer", () => {
 
 describe("POST /api/v1/test-pin-scope", () => {
     it("does not allow pin-based auth outside digipog HTTP APIs", async () => {
-        const { hash } = require("@modules/crypto");
-        const pinHash = await hash("1234");
+        const { hashBcrypt } = require("@modules/crypto");
+        const pinHash = await hashBcrypt("1234");
 
         const { user } = await seedAuthenticatedUser(mockDatabase, {
             email: "pinonly@example.com",

--- a/api/v1/controllers/tests/digipogs.spec.js
+++ b/api/v1/controllers/tests/digipogs.spec.js
@@ -186,68 +186,24 @@ describe("POST /api/v1/digipogs/award", () => {
 });
 
 describe("POST /api/v1/digipogs/transfer", () => {
-    it("returns 401 without authentication", async () => {
-        const res = await request(app).post("/api/v1/digipogs/transfer").send({ to: "1", amount: 5, pin: "1234" });
-
-        expect(res.status).toBe(401);
-    });
-
-    it("returns 403 for a guest user (permissions=1) who lacks global.digipogs.transfer", async () => {
-        const { tokens, user } = await seedAuthenticatedUser(mockDatabase, {
-            email: "guest@example.com",
-            displayName: "Guest",
-            permissions: 1,
-        });
-
-        const res = await request(app)
-            .post("/api/v1/digipogs/transfer")
-            .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ from: user.id, to: "1", amount: 5, pin: "1234" });
-
-        expect(res.status).toBe(403);
-    });
-
-    it("returns 403 for a banned user (permissions=0)", async () => {
-        const { tokens, user } = await seedAuthenticatedUser(mockDatabase, {
-            email: "banned@example.com",
-            displayName: "Banned",
-            permissions: 0,
-        });
-
-        const res = await request(app)
-            .post("/api/v1/digipogs/transfer")
-            .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ from: user.id, to: "1", amount: 5, pin: "1234" });
-
-        expect(res.status).toBe(403);
-    });
-
     it("returns 400 when required fields (to, amount, pin) are missing", async () => {
-        const { tokens } = await seedAuthenticatedUser(mockDatabase);
-
-        const res = await request(app).post("/api/v1/digipogs/transfer").set("Authorization", `Bearer ${tokens.accessToken}`).send({});
+        const res = await request(app).post("/api/v1/digipogs/transfer").send({});
 
         expect(res.status).toBe(400);
     });
 
     it("returns 400 when pin is missing", async () => {
-        const { tokens, user } = await seedAuthenticatedUser(mockDatabase);
+        const { user } = await seedAuthenticatedUser(mockDatabase);
 
-        const res = await request(app)
-            .post("/api/v1/digipogs/transfer")
-            .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ from: user.id, to: "999", amount: 5 });
+        const res = await request(app).post("/api/v1/digipogs/transfer").send({ from: user.id, to: "999", amount: 5 });
 
         expect(res.status).toBe(400);
     });
 
     it("returns 400 when amount is missing", async () => {
-        const { tokens, user } = await seedAuthenticatedUser(mockDatabase);
+        const { user } = await seedAuthenticatedUser(mockDatabase);
 
-        const res = await request(app)
-            .post("/api/v1/digipogs/transfer")
-            .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ from: user.id, to: "999", pin: "1234" });
+        const res = await request(app).post("/api/v1/digipogs/transfer").send({ from: user.id, to: "999", pin: "1234" });
 
         expect(res.status).toBe(400);
     });
@@ -257,7 +213,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
         const pinHash = await hashBcrypt("1234");
 
         // Seed sender with digipogs and a pin
-        const { tokens, user: sender } = await seedAuthenticatedUser(mockDatabase);
+        const { user: sender } = await seedAuthenticatedUser(mockDatabase);
         await mockDatabase.dbRun("UPDATE users SET digipogs = 100, pin = ? WHERE id = ?", [pinHash, sender.id]);
 
         // Seed recipient
@@ -267,10 +223,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
             permissions: 2,
         });
 
-        const res = await request(app)
-            .post("/api/v1/digipogs/transfer")
-            .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ from: sender.id, to: recipient.id, amount: 10, pin: "1234" });
+        const res = await request(app).post("/api/v1/digipogs/transfer").send({ from: sender.id, to: recipient.id, amount: 10, pin: "1234" });
 
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
@@ -299,11 +252,30 @@ describe("POST /api/v1/digipogs/transfer", () => {
         expect(res.body.success).toBe(true);
     });
 
+    it("accepts fromUserId as a sender alias for PIN-only transfers", async () => {
+        const { hashBcrypt } = require("@modules/crypto");
+        const pinHash = await hashBcrypt("1234");
+
+        const { user: sender } = await seedAuthenticatedUser(mockDatabase);
+        await mockDatabase.dbRun("UPDATE users SET digipogs = 100, pin = ? WHERE id = ?", [pinHash, sender.id]);
+
+        const { user: recipient } = await seedAuthenticatedUser(mockDatabase, {
+            email: "pin-alias-recipient@example.com",
+            displayName: "PIN Alias Recipient",
+            permissions: 2,
+        });
+
+        const res = await request(app).post("/api/v1/digipogs/transfer").send({ fromUserId: sender.id, to: recipient.id, amount: 10, pin: "1234" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
     it("returns 400 when the sender has insufficient funds", async () => {
         const { hashBcrypt } = require("@modules/crypto");
         const pinHash = await hashBcrypt("1234");
 
-        const { tokens, user: sender } = await seedAuthenticatedUser(mockDatabase);
+        const { user: sender } = await seedAuthenticatedUser(mockDatabase);
         await mockDatabase.dbRun("UPDATE users SET digipogs = 0, pin = ? WHERE id = ?", [pinHash, sender.id]);
 
         const { user: recipient } = await seedAuthenticatedUser(mockDatabase, {
@@ -312,10 +284,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
             permissions: 2,
         });
 
-        const res = await request(app)
-            .post("/api/v1/digipogs/transfer")
-            .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ from: sender.id, to: recipient.id, amount: 50, pin: "1234" });
+        const res = await request(app).post("/api/v1/digipogs/transfer").send({ from: sender.id, to: recipient.id, amount: 50, pin: "1234" });
 
         expect(res.status).toBe(400);
     });
@@ -324,7 +293,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
         const { hashBcrypt } = require("@modules/crypto");
         const pinHash = await hashBcrypt("1234");
 
-        const { tokens, user: sender } = await seedAuthenticatedUser(mockDatabase);
+        const { user: sender } = await seedAuthenticatedUser(mockDatabase);
         await mockDatabase.dbRun("UPDATE users SET digipogs = 100, pin = ? WHERE id = ?", [pinHash, sender.id]);
 
         const { user: recipient } = await seedAuthenticatedUser(mockDatabase, {
@@ -333,10 +302,7 @@ describe("POST /api/v1/digipogs/transfer", () => {
             permissions: 2,
         });
 
-        const res = await request(app)
-            .post("/api/v1/digipogs/transfer")
-            .set("Authorization", `Bearer ${tokens.accessToken}`)
-            .send({ from: sender.id, to: recipient.id, amount: 10, pin: "wrong" });
+        const res = await request(app).post("/api/v1/digipogs/transfer").send({ from: sender.id, to: recipient.id, amount: 10, pin: "wrong" });
 
         expect(res.status).toBe(400);
     });

--- a/api/v1/controllers/tests/user.spec.js
+++ b/api/v1/controllers/tests/user.spec.js
@@ -132,6 +132,18 @@ describe("GET /api/v1/user/:id", () => {
         });
     });
 
+    it("still returns 200 when the stored API key is null", async () => {
+        const { user } = await seedStudent();
+        const row = await mockDatabase.dbGet("SELECT API FROM users WHERE id = ?", [user.id]);
+
+        expect(row.API).toBeNull();
+
+        const res = await request(app).get(`/api/v1/user/${user.id}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
     it("returns 404 for a non-existent user", async () => {
         const res = await request(app).get("/api/v1/user/99999");
 

--- a/api/v1/controllers/user/user.js
+++ b/api/v1/controllers/user/user.js
@@ -55,8 +55,8 @@ module.exports = (router) => {
             throw new NotFoundError("User not found.", { event: "user.get.failed", reason: "user_not_found" });
         }
 
-        const { id, displayName, email, digipogs, API, pin, password, permissions, verified } = userData;
-        if (!id || !displayName || !email || digipogs === undefined || !API) {
+        const { id, displayName, email, digipogs, pin, password, permissions, verified } = userData;
+        if (!id || !displayName || !email || digipogs === undefined) {
             throw new AppError("Unable to retrieve user information. Please try again.", {
                 event: "user.get.failed",
                 reason: "missing_required_fields",

--- a/database/migrate.js
+++ b/database/migrate.js
@@ -4,7 +4,7 @@ require("module-alias/register");
 const sqlite3 = require("sqlite3").verbose();
 const fs = require("fs");
 const { decrypt } = require("./modules/crypto"); // Old crypto module
-const { hash } = require("@modules/crypto"); // New crypto module
+const { hashBcrypt } = require("@modules/crypto");
 
 // Get all migration files and sort them by filename
 const sqlMigrations = fs
@@ -114,7 +114,7 @@ async function executeSQLMigration(migration) {
                                 for (const user of users) {
                                     if (user.email !== undefined) continue;
                                     const decryptedPassword = decrypt(JSON.parse(user.password));
-                                    const hashedPassword = await hash(decryptedPassword);
+                                    const hashedPassword = await hashBcrypt(decryptedPassword);
                                     database.run("UPDATE users SET password=? WHERE id=?", [hashedPassword, user.id]);
                                 }
                             });

--- a/database/migrations/28_allow_null_api_key.sql
+++ b/database/migrations/28_allow_null_api_key.sql
@@ -1,0 +1,18 @@
+// 28_allow_null_api_key
+// Allows null API keys to avoid wasting CPU compute on hashing when users are registered
+
+ALTER TABLE users RENAME TO users_temp
+
+CREATE TABLE users (
+    id INTEGER NOT NULL UNIQUE,
+    email TEXT NOT NULL UNIQUE,
+    password TEXT,
+    API TEXT,
+    secret TEXT NOT NULL UNIQUE,
+    tags TEXT,
+    digipogs INTEGER NOT NULL DEFAULT 0,
+    pin TEXT,
+    displayName TEXT,
+    verified INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (id AUTOINCREMENT)
+);

--- a/database/migrations/28_allow_null_api_key.sql
+++ b/database/migrations/28_allow_null_api_key.sql
@@ -1,13 +1,13 @@
-// 28_allow_null_api_key
-// Allows null API keys to avoid wasting CPU compute on hashing when users are registered
+-- 28_allow_null_api_key
+-- Allows null API keys while keeping API values unique for indexed lookups.
 
-ALTER TABLE users RENAME TO users_temp
+ALTER TABLE users RENAME TO users_temp;
 
 CREATE TABLE users (
     id INTEGER NOT NULL UNIQUE,
     email TEXT NOT NULL UNIQUE,
     password TEXT,
-    API TEXT,
+    API TEXT UNIQUE,
     secret TEXT NOT NULL UNIQUE,
     tags TEXT,
     digipogs INTEGER NOT NULL DEFAULT 0,
@@ -16,3 +16,11 @@ CREATE TABLE users (
     verified INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (id AUTOINCREMENT)
 );
+
+INSERT INTO users (id, email, password, API, secret, tags, digipogs, pin, displayName, verified)
+SELECT id, email, password, API, secret, tags, digipogs, pin, displayName, verified
+FROM users_temp;
+
+DROP TABLE users_temp;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_display_name_unique ON users (displayName);

--- a/database/migrations/JSMigrations/09_hash_api_keys_and_pins.js
+++ b/database/migrations/JSMigrations/09_hash_api_keys_and_pins.js
@@ -1,7 +1,7 @@
 // 09_hash_api_keys_and_pins.js
 // This migration hashes all existing API keys and PINs in the users table
 
-const { hash } = require("@modules/crypto");
+const { hashBcrypt } = require("@modules/crypto");
 const { dbGet, dbRun, dbGetAll } = require("@modules/database");
 
 module.exports = {
@@ -38,12 +38,12 @@ module.exports = {
         // Hash and migrate each user's data
         for (const user of users) {
             // Hash the API key
-            const hashedAPI = await hash(user.API);
+            const hashedAPI = await hashBcrypt(user.API);
 
             // Hash the PIN if it exists
             let hashedPin = null;
             if (user.pin) {
-                hashedPin = await hash(user.pin.toString());
+                hashedPin = await hashBcrypt(user.pin.toString());
             }
 
             // Insert the user into the new table with hashed values

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,16 +1,20 @@
 // Prevent the tests from using the logger as it can cause tests to fail
-jest.mock("./modules/logger.js", () => ({
-    logger: {
-        log: jest.fn(),
-    },
-    getLogger: jest.fn().mockResolvedValue({
+jest.mock("./modules/logger.js", () => {
+    const logger = {
         log: jest.fn(),
         info: jest.fn(),
         error: jest.fn(),
         warn: jest.fn(),
-    }),
-    logEvent: jest.fn(),
-}));
+        close: jest.fn(),
+    };
+    logger.child = jest.fn(() => logger);
+
+    return {
+        logger,
+        getLogger: jest.fn().mockResolvedValue(logger),
+        logEvent: jest.fn(),
+    };
+});
 
 // Prevent tests from using the actual database
 jest.mock("./modules/database", () => ({

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -1,12 +1,11 @@
 const { getLogger } = require("@modules/logger");
 const { classStateStore } = require("@services/classroom-service");
 const { settings } = require("@modules/config");
-const { dbGet, dbGetAll, dbRun } = require("@modules/database");
-const { compareBcrypt } = require("@modules/crypto");
+const { dbGet, dbRun } = require("@modules/database");
 const { createStudentFromUserData } = require("@services/student-service");
 const { getUserDataFromDb } = require("@services/user-service");
+const { resolveAPIKey } = require("@services/api-key-service");
 const { verifyToken, cleanupExpiredAuthorizationCodes } = require("@services/auth-service");
-const { apiKeyCacheStore } = require("@stores/api-key-cache-store");
 const AuthError = require("@errors/auth-error");
 
 const whitelistedIps = {};
@@ -15,12 +14,7 @@ const blacklistedIps = {};
 // Removes expired refresh tokens and authorization codes from the database
 async function cleanRefreshTokens() {
     try {
-        const refreshTokens = await dbGetAll("SELECT * FROM refresh_tokens");
-        for (const refreshToken of refreshTokens) {
-            if (Date.now() >= refreshToken.exp) {
-                await dbRun("DELETE FROM refresh_tokens WHERE token_hash = ?", [refreshToken.token_hash]);
-            }
-        }
+        await dbRun("DELETE FROM refresh_tokens WHERE exp <= ?", [Date.now()]);
         // Also clean up expired authorization codes
         await cleanupExpiredAuthorizationCodes();
     } catch (err) {
@@ -85,27 +79,8 @@ async function isAuthenticated(req, res, next) {
     const apiKeyHeader = req.headers.api || req.query.api || req.body.api;
     const apiKey = typeof apiKeyHeader === "string" ? apiKeyHeader.trim() : null;
     if (apiKey) {
-        let apiUser = null;
-
-        // Fast path: check the in-memory cache to avoid bcrypt comparisons on repeat requests.
-        const cachedEmail = apiKeyCacheStore.get(apiKey);
-        if (cachedEmail) {
-            apiUser = await loadComputedUserByEmail(cachedEmail);
-        }
-
-        // Slow path: cache miss — scan all users with an API key and bcrypt-compare each one.
-        if (!apiUser) {
-            const users = await dbGetAll("SELECT * FROM users WHERE API IS NOT NULL");
-            for (const user of users) {
-                if (!user.API) continue;
-                const matches = await compareBcrypt(apiKey, user.API);
-                if (matches) {
-                    apiUser = await getUserDataFromDb(user.id);
-                    apiKeyCacheStore.set(apiKey, user.email);
-                    break;
-                }
-            }
-        }
+        const apiKeyUser = await resolveAPIKey(apiKey);
+        const apiUser = apiKeyUser ? await getUserDataFromDb(apiKeyUser.id) : null;
 
         if (!apiUser) {
             req.warnEvent("auth.invalid_api_key", "Invalid API key provided");

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -2,7 +2,7 @@ const { getLogger } = require("@modules/logger");
 const { classStateStore } = require("@services/classroom-service");
 const { settings } = require("@modules/config");
 const { dbGet, dbGetAll, dbRun } = require("@modules/database");
-const { compare } = require("@modules/crypto");
+const { compareBcrypt } = require("@modules/crypto");
 const { createStudentFromUserData } = require("@services/student-service");
 const { getUserDataFromDb } = require("@services/user-service");
 const { verifyToken, cleanupExpiredAuthorizationCodes } = require("@services/auth-service");
@@ -98,7 +98,7 @@ async function isAuthenticated(req, res, next) {
             const users = await dbGetAll("SELECT * FROM users WHERE API IS NOT NULL");
             for (const user of users) {
                 if (!user.API) continue;
-                const matches = await compare(apiKey, user.API);
+                const matches = await compareBcrypt(apiKey, user.API);
                 if (matches) {
                     apiUser = await getUserDataFromDb(user.id);
                     apiKeyCacheStore.set(apiKey, user.email);

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -14,7 +14,8 @@ const blacklistedIps = {};
 // Removes expired refresh tokens and authorization codes from the database
 async function cleanRefreshTokens() {
     try {
-        await dbRun("DELETE FROM refresh_tokens WHERE exp <= ?", [Date.now()]);
+        const nowInSeconds = Math.floor(Date.now() / 1000);
+        await dbRun("DELETE FROM refresh_tokens WHERE exp <= ?", [nowInSeconds]);
         // Also clean up expired authorization codes
         await cleanupExpiredAuthorizationCodes();
     } catch (err) {

--- a/middleware/permission-check.js
+++ b/middleware/permission-check.js
@@ -1,5 +1,5 @@
 const { classStateStore } = require("@services/classroom-service");
-const { dbGet, dbGetAll } = require("@modules/database");
+const { dbGet } = require("@modules/database");
 const { compareBcrypt } = require("@modules/crypto");
 const { userHasScope } = require("@modules/scope-resolver");
 const { createStudentFromUserData } = require("@services/student-service");
@@ -24,6 +24,43 @@ function isDigipogHttpApiRequest(req) {
     return DIGIPOG_HTTP_API_PATH.test(req.originalUrl || req.baseUrl || req.path || "");
 }
 
+function normalizeTransferFrom(body) {
+    const rawFrom = body?.from ?? body?.fromUserId ?? body?.userId;
+    if (rawFrom === undefined || rawFrom === null || rawFrom === "") {
+        return null;
+    }
+
+    if (typeof rawFrom === "object") {
+        const type = rawFrom.type || "user";
+        const id = Number(rawFrom.id ?? rawFrom.userId ?? rawFrom.poolId);
+        if (!Number.isInteger(id) || id <= 0 || !["user", "pool"].includes(type)) {
+            return null;
+        }
+        return { id, type };
+    }
+
+    const id = Number(rawFrom);
+    if (!Number.isInteger(id) || id <= 0) {
+        return null;
+    }
+    return { id, type: "user" };
+}
+
+async function getPinAuthUser(from) {
+    if (from.type === "user") {
+        return dbGet("SELECT id, pin FROM users WHERE id = ? AND pin IS NOT NULL", [from.id]);
+    }
+
+    return dbGet(
+        `SELECT u.id, u.pin
+         FROM digipog_pool_users dpu
+         JOIN users u ON u.id = dpu.user_id
+         WHERE dpu.pool_id = ? AND dpu.owner = 1 AND u.pin IS NOT NULL
+         LIMIT 1`,
+        [from.id]
+    );
+}
+
 async function attachDigipogPinUser(req, res) {
     if (!isDigipogHttpApiRequest(req) || req.user?.email) {
         return;
@@ -38,27 +75,17 @@ async function attachDigipogPinUser(req, res) {
         return;
     }
 
-    const pin = String(req.body.pin);
-    const users = await dbGetAll("SELECT id, pin FROM users WHERE pin IS NOT NULL");
-    let matchedUserId = null;
-
-    for (const candidate of users) {
-        if (!candidate.pin || !(await compareBcrypt(pin, candidate.pin))) {
-            continue;
-        }
-
-        if (matchedUserId && matchedUserId !== candidate.id) {
-            return;
-        }
-
-        matchedUserId = candidate.id;
+    const from = normalizeTransferFrom(req.body);
+    if (!from) {
+        return new AuthError("Missing sender identifier.");
     }
 
-    if (!matchedUserId) {
+    const candidate = await getPinAuthUser(from);
+    if (!candidate || !(await compareBcrypt(String(req.body.pin), candidate.pin))) {
         return new AuthError("Invalid PIN.");
     }
 
-    const userData = await getUserDataFromDb(matchedUserId);
+    const userData = await getUserDataFromDb(candidate.id);
     if (!userData) {
         return;
     }
@@ -75,6 +102,7 @@ async function attachDigipogPinUser(req, res) {
         id: user.id || userData.id,
         userId: user.id || userData.id,
     };
+    req.pinAuthenticatedFrom = from;
 }
 
 /**

--- a/middleware/permission-check.js
+++ b/middleware/permission-check.js
@@ -1,6 +1,6 @@
 const { classStateStore } = require("@services/classroom-service");
 const { dbGet, dbGetAll } = require("@modules/database");
-const { compare } = require("@modules/crypto");
+const { compareBcrypt } = require("@modules/crypto");
 const { userHasScope } = require("@modules/scope-resolver");
 const { createStudentFromUserData } = require("@services/student-service");
 const { getUserDataFromDb } = require("@services/user-service");
@@ -43,7 +43,7 @@ async function attachDigipogPinUser(req, res) {
     let matchedUserId = null;
 
     for (const candidate of users) {
-        if (!candidate.pin || !(await compare(pin, candidate.pin))) {
+        if (!candidate.pin || !(await compareBcrypt(pin, candidate.pin))) {
             continue;
         }
 

--- a/middleware/permission-check.js
+++ b/middleware/permission-check.js
@@ -1,15 +1,10 @@
 const { classStateStore } = require("@services/classroom-service");
 const { dbGet } = require("@modules/database");
-const { compareBcrypt } = require("@modules/crypto");
 const { userHasScope } = require("@modules/scope-resolver");
-const { createStudentFromUserData } = require("@services/student-service");
-const { getUserDataFromDb } = require("@services/user-service");
-const { isAuthenticated } = require("@middleware/authentication");
 const AuthError = require("@errors/auth-error");
 const ForbiddenError = require("@errors/forbidden-error");
 const NotFoundError = require("@errors/not-found-error");
 const ValidationError = require("@errors/validation-error");
-const DIGIPOG_HTTP_API_PATH = /^\/api(?:\/v\d+)?\/digipogs(?:\/|$|\?)/i;
 
 /** Express path params are strings; in-memory classrooms are keyed by numeric id from the DB. */
 function normalizeClassId(raw) {
@@ -20,91 +15,6 @@ function normalizeClassId(raw) {
     return Number.isNaN(n) ? raw : n;
 }
 
-function isDigipogHttpApiRequest(req) {
-    return DIGIPOG_HTTP_API_PATH.test(req.originalUrl || req.baseUrl || req.path || "");
-}
-
-function normalizeTransferFrom(body) {
-    const rawFrom = body?.from ?? body?.fromUserId ?? body?.userId;
-    if (rawFrom === undefined || rawFrom === null || rawFrom === "") {
-        return null;
-    }
-
-    if (typeof rawFrom === "object") {
-        const type = rawFrom.type || "user";
-        const id = Number(rawFrom.id ?? rawFrom.userId ?? rawFrom.poolId);
-        if (!Number.isInteger(id) || id <= 0 || !["user", "pool"].includes(type)) {
-            return null;
-        }
-        return { id, type };
-    }
-
-    const id = Number(rawFrom);
-    if (!Number.isInteger(id) || id <= 0) {
-        return null;
-    }
-    return { id, type: "user" };
-}
-
-async function getPinAuthUser(from) {
-    if (from.type === "user") {
-        return dbGet("SELECT id, pin FROM users WHERE id = ? AND pin IS NOT NULL", [from.id]);
-    }
-
-    return dbGet(
-        `SELECT u.id, u.pin
-         FROM digipog_pool_users dpu
-         JOIN users u ON u.id = dpu.user_id
-         WHERE dpu.pool_id = ? AND dpu.owner = 1 AND u.pin IS NOT NULL
-         LIMIT 1`,
-        [from.id]
-    );
-}
-
-async function attachDigipogPinUser(req, res) {
-    if (!isDigipogHttpApiRequest(req) || req.user?.email) {
-        return;
-    }
-
-    const hasStandardAuth = Boolean(req.headers.authorization || req.headers.api || req.query.api || req.body?.api);
-    if (hasStandardAuth) {
-        await isAuthenticated(req, res, () => {});
-    }
-
-    if (!req.body?.pin || req.user?.email) {
-        return;
-    }
-
-    const from = normalizeTransferFrom(req.body);
-    if (!from) {
-        return new AuthError("Missing sender identifier.");
-    }
-
-    const candidate = await getPinAuthUser(from);
-    if (!candidate || !(await compareBcrypt(String(req.body.pin), candidate.pin))) {
-        return new AuthError("Invalid PIN.");
-    }
-
-    const userData = await getUserDataFromDb(candidate.id);
-    if (!userData) {
-        return;
-    }
-
-    let user = classStateStore.getUser(userData.email);
-    if (!user) {
-        user = createStudentFromUserData(userData, { isGuest: false });
-        classStateStore.setUser(userData.email, user);
-    }
-
-    req.user = {
-        email: userData.email,
-        ...user,
-        id: user.id || userData.id,
-        userId: user.id || userData.id,
-    };
-    req.pinAuthenticatedFrom = from;
-}
-
 /**
  * Middleware to check if a user has a specific global scope.
  * Uses the new scope-based permission system with backward-compatible role resolution.
@@ -113,11 +23,6 @@ async function attachDigipogPinUser(req, res) {
  */
 function hasScope(scope) {
     return async function (req, res, next) {
-        const result = await attachDigipogPinUser(req, res);
-        if (result instanceof AuthError) {
-            throw result;
-        }
-
         if (!req.user || !req.user.email) {
             req.warnEvent("auth.scope_check.not_authenticated", "Scope check failed: User is not authenticated");
             throw new AuthError("User is not authenticated");
@@ -154,11 +59,6 @@ function hasScope(scope) {
  */
 function hasClassScope(scope) {
     return async function (req, res, next) {
-        const result = await attachDigipogPinUser(req, res);
-        if (result instanceof AuthError) {
-            throw result;
-        }
-
         if (!req.user || !req.user.email) {
             req.warnEvent("auth.class_scope_check.not_authenticated", "Class scope check failed: User is not authenticated");
             throw new AuthError("User is not authenticated", { event: "permission.check.failed", reason: "not_authenticated" });

--- a/middleware/rate-limiter.js
+++ b/middleware/rate-limiter.js
@@ -8,6 +8,12 @@ const { getUserScopes } = require("@modules/scope-resolver");
 // Structure: { identifier: { path: [timestamps], hasBeenMessaged: bool } }
 const rateLimits = {};
 
+const TIMED_RATE_LIMIT_WINDOW_MS = 60000;
+const UNAUTHENTICATED_USER_RATE_LIMIT = 25;
+const AUTHENTICATED_USER_RATE_LIMIT = 120;
+const AUTHENTICATED_USER_RATE_LIMIT_FOR_AUTH_PATHS = 25;
+const TEACHER_RATE_LIMIT = 225;
+
 async function rateLimiter(req, res, next) {
     let user = null;
     if (req.headers.api) {
@@ -31,16 +37,18 @@ async function rateLimiter(req, res, next) {
 
     const identifier = user.email;
     const currentTime = Date.now();
-    const timeFrame = settings.rateLimitWindowMs ?? 60000;
-    let limit = 10; // Default limit for unauthenticated users
+    const timeFrame = settings.rateLimitWindowMs ?? TIMED_RATE_LIMIT_WINDOW_MS;
     const permissionLevel = computeGlobalPermissionLevel(getUserScopes(user).global);
+    
+    let maximumRequests = UNAUTHENTICATED_USER_RATE_LIMIT; // Default limit for unauthenticated users
     if (permissionLevel >= TEACHER_PERMISSIONS) {
-        limit = 225;
+        maximumRequests = TEACHER_RATE_LIMIT;
     } else if (permissionLevel >= STUDENT_PERMISSIONS) {
-        limit = req.path.startsWith("/auth/") ? 10 : 120;
+        maximumRequests = req.path.startsWith("/auth/") ? AUTHENTICATED_USER_RATE_LIMIT_FOR_AUTH_PATHS : AUTHENTICATED_USER_RATE_LIMIT;
     }
+
     // Apply the configurable multiplier so test runs can relax limits.
-    limit = Math.max(1, Math.round(limit * (settings.rateLimitMultiplier ?? 1)));
+    maximumRequests = Math.max(1, Math.round(maximumRequests * (settings.rateLimitMultiplier ?? 1)));
 
     // Initialize rate limit log for the user if it doesn't exist
     if (!rateLimits[identifier]) {
@@ -65,13 +73,13 @@ async function rateLimiter(req, res, next) {
     // Check if the user has exceeded the limit
     // If they have, send a rate limit response
     // Otherwise, log the request and proceed
-    if (userRequests[path].length >= limit) {
+    if (userRequests[path].length >= maximumRequests) {
         if (!userRequests["hasBeenMessaged"]) {
             userRequests["hasBeenMessaged"] = true;
             req.warnEvent("rate_limit.exceeded", `Rate limit exceeded for user ${identifier} on path ${path}`, {
                 identifier,
                 path,
-                limit,
+                limit: maximumRequests,
                 permissionLevel,
             });
         }

--- a/middleware/rate-limiter.js
+++ b/middleware/rate-limiter.js
@@ -1,4 +1,6 @@
-const { getUser } = require("@services/user-service");
+const { getUserDataFromDb } = require("@services/user-service");
+const { resolveAPIKey } = require("@services/api-key-service");
+const { dbGet } = require("@modules/database");
 const { verifyToken } = require("@services/auth-service");
 const { settings } = require("@modules/config");
 const { computeGlobalPermissionLevel, STUDENT_PERMISSIONS, TEACHER_PERMISSIONS } = require("@modules/permissions");
@@ -14,32 +16,45 @@ const AUTHENTICATED_USER_RATE_LIMIT = 120;
 const AUTHENTICATED_USER_RATE_LIMIT_FOR_AUTH_PATHS = 25;
 const TEACHER_RATE_LIMIT = 225;
 
-async function rateLimiter(req, res, next) {
-    let user = null;
-    if (req.headers.api) {
-        user = await getUser({ api: req.headers.api });
-    } else if (req.headers.authorization) {
-        const decodedToken = verifyToken(req.headers.authorization);
-        if (!decodedToken || decodedToken.error || !decodedToken.email) {
-            user = { email: req.ip };
-        } else {
-            let email = decodedToken.email;
-            user = await getUser({ email: email });
+async function resolveRateLimitIdentity(req) {
+    const fallbackIdentity = `ip:${req.ip || "unknown"}`;
+
+    const apiKeyHeader = req.headers.api;
+    const apiKey = typeof apiKeyHeader === "string" ? apiKeyHeader.trim() : null;
+    if (apiKey) {
+        const apiKeyUser = await resolveAPIKey(apiKey);
+        if (apiKeyUser?.id) {
+            const userData = await getUserDataFromDb(apiKeyUser.id);
+            if (userData?.id) {
+                return { identifier: `user:${userData.id}`, user: userData };
+            }
         }
-    } else {
-        user = { email: req.ip };
+        return { identifier: fallbackIdentity, user: null };
     }
 
-    // Fallback for invalid user data
-    if (!user || user.error || !user.email) {
-        user = { email: req.ip };
+    const authorizationHeader = req.headers.authorization;
+    if (authorizationHeader) {
+        const decodedToken = verifyToken(authorizationHeader);
+        if (decodedToken && !decodedToken.error && decodedToken.email) {
+            const userRow = await dbGet("SELECT id FROM users WHERE email = ?", [decodedToken.email]);
+            if (userRow?.id) {
+                const userData = await getUserDataFromDb(userRow.id);
+                if (userData?.id) {
+                    return { identifier: `user:${userData.id}`, user: userData };
+                }
+            }
+        }
     }
 
-    const identifier = user.email;
+    return { identifier: fallbackIdentity, user: null };
+}
+
+async function rateLimiter(req, res, next) {
+    const { identifier, user } = await resolveRateLimitIdentity(req);
     const currentTime = Date.now();
     const timeFrame = settings.rateLimitWindowMs ?? TIMED_RATE_LIMIT_WINDOW_MS;
-    const permissionLevel = computeGlobalPermissionLevel(getUserScopes(user).global);
-    
+    const permissionLevel = user ? computeGlobalPermissionLevel(getUserScopes(user).global) : 0;
+
     let maximumRequests = UNAUTHENTICATED_USER_RATE_LIMIT; // Default limit for unauthenticated users
     if (permissionLevel >= TEACHER_PERMISSIONS) {
         maximumRequests = TEACHER_RATE_LIMIT;

--- a/middleware/tests/authentication.spec.js
+++ b/middleware/tests/authentication.spec.js
@@ -1,0 +1,65 @@
+const { createTestDb } = require("@test-helpers/db");
+
+let mockDatabase;
+
+jest.mock("@modules/database", () => ({
+    dbGet: (...args) => mockDatabase.dbGet(...args),
+    dbRun: (...args) => mockDatabase.dbRun(...args),
+}));
+
+const mockCleanupExpiredAuthorizationCodes = jest.fn().mockResolvedValue();
+
+jest.mock("@services/auth-service", () => ({
+    cleanupExpiredAuthorizationCodes: (...args) => mockCleanupExpiredAuthorizationCodes(...args),
+    verifyToken: jest.fn(),
+}));
+
+jest.mock("@modules/logger", () => ({
+    getLogger: jest.fn().mockResolvedValue({
+        error: jest.fn(),
+    }),
+}));
+
+jest.mock("@modules/config", () => ({
+    settings: { emailEnabled: false },
+}));
+
+const { cleanRefreshTokens } = require("@middleware/authentication");
+
+beforeAll(async () => {
+    mockDatabase = await createTestDb();
+});
+
+afterEach(async () => {
+    await mockDatabase.reset();
+    mockCleanupExpiredAuthorizationCodes.mockClear();
+});
+
+afterAll(async () => {
+    await mockDatabase.close();
+});
+
+describe("cleanRefreshTokens()", () => {
+    it("deletes only refresh tokens whose exp has passed in JWT seconds", async () => {
+        const nowInSeconds = Math.floor(Date.now() / 1000);
+
+        await mockDatabase.dbRun("INSERT INTO refresh_tokens (user_id, token_hash, exp, token_type) VALUES (?, ?, ?, ?)", [
+            1,
+            "expired-token",
+            nowInSeconds - 1,
+            "auth",
+        ]);
+        await mockDatabase.dbRun("INSERT INTO refresh_tokens (user_id, token_hash, exp, token_type) VALUES (?, ?, ?, ?)", [
+            1,
+            "active-token",
+            nowInSeconds + 3600,
+            "auth",
+        ]);
+
+        await cleanRefreshTokens();
+
+        const remaining = await mockDatabase.dbGetAll("SELECT token_hash FROM refresh_tokens ORDER BY token_hash");
+        expect(remaining).toEqual([{ token_hash: "active-token" }]);
+        expect(mockCleanupExpiredAuthorizationCodes).toHaveBeenCalledTimes(1);
+    });
+});

--- a/middleware/tests/rate-limiter.spec.js
+++ b/middleware/tests/rate-limiter.spec.js
@@ -1,0 +1,93 @@
+jest.mock("@modules/database", () => ({
+    dbGet: jest.fn(),
+}));
+
+jest.mock("@services/api-key-service", () => ({
+    resolveAPIKey: jest.fn(),
+}));
+
+jest.mock("@services/user-service", () => ({
+    getUserDataFromDb: jest.fn(),
+}));
+
+jest.mock("@services/auth-service", () => ({
+    verifyToken: jest.fn(),
+}));
+
+jest.mock("@modules/config", () => ({
+    settings: {
+        rateLimitWindowMs: 60000,
+        rateLimitMultiplier: 0.04,
+    },
+}));
+
+jest.mock("@modules/permissions", () => ({
+    computeGlobalPermissionLevel: jest.fn(() => 0),
+    STUDENT_PERMISSIONS: 2,
+    TEACHER_PERMISSIONS: 4,
+}));
+
+jest.mock("@modules/scope-resolver", () => ({
+    getUserScopes: jest.fn(() => ({ global: [], class: [] })),
+}));
+
+const { rateLimiter } = require("@middleware/rate-limiter");
+const { resolveAPIKey } = require("@services/api-key-service");
+const { getUserDataFromDb } = require("@services/user-service");
+const { verifyToken } = require("@services/auth-service");
+const { dbGet } = require("@modules/database");
+
+function createReq({ api, authorization, path = "/api/v1/example", ip = "127.0.0.1" }) {
+    return {
+        headers: {
+            ...(api !== undefined ? { api } : {}),
+            ...(authorization !== undefined ? { authorization } : {}),
+        },
+        path,
+        ip,
+        body: {},
+        query: {},
+        warnEvent: jest.fn(),
+    };
+}
+
+function createRes() {
+    return {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+    };
+}
+
+describe("HTTP rate-limiter middleware", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("keys authenticated buckets by user id instead of email", async () => {
+        resolveAPIKey.mockResolvedValue({ id: 42, email: "api-user@example.com" });
+        verifyToken.mockReturnValue({ email: "token-user@example.com" });
+        dbGet.mockResolvedValue({ id: 42 });
+        getUserDataFromDb.mockResolvedValue({ id: 42, email: "token-user@example.com", roles: { global: [], class: [] } });
+
+        const apiReq = createReq({ api: "api-key-1" });
+        const apiRes = createRes();
+        const apiNext = jest.fn();
+        await rateLimiter(apiReq, apiRes, apiNext);
+
+        expect(apiNext).toHaveBeenCalledTimes(1);
+        expect(apiRes.status).not.toHaveBeenCalled();
+
+        const tokenReq = createReq({ authorization: "token-1" });
+        const tokenRes = createRes();
+        const tokenNext = jest.fn();
+        await rateLimiter(tokenReq, tokenRes, tokenNext);
+
+        expect(tokenNext).not.toHaveBeenCalled();
+        expect(tokenRes.status).toHaveBeenCalledWith(429);
+        expect(tokenRes.json).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: expect.stringContaining("Please try again"),
+            })
+        );
+    });
+});

--- a/modules/crypto.js
+++ b/modules/crypto.js
@@ -76,7 +76,7 @@ function compareBcrypt(text, hash) {
  * @returns {boolean} True if the hash is a bcrypt hash, false otherwise.
  */
 function isBcryptHash(hash) {
-    return typeof hash === "string" && hash.startsWith("$2b$");
+    return typeof hash === "string" && /^\$2[aby]\$\d{2}\$/.test(hash);
 }
 
 /**

--- a/modules/crypto.js
+++ b/modules/crypto.js
@@ -10,7 +10,7 @@ const saltRounds = parseInt(process.env.SALT_ROUNDS, 10) || 10;
  * @param {string} text - The text to be hashed.
  * @returns {Promise<string>} A promise that resolves to the hashed text.
  */
-function hash(text) {
+function hashBcrypt(text) {
     return new Promise((resolve, reject) => {
         // Validate that text is a string
         if (typeof text !== "string") {
@@ -46,7 +46,7 @@ function hash(text) {
  * @param {string} hash - The hash to compare against.
  * @returns {Promise<boolean>} A promise that resolves to true if the text matches the hash, otherwise false.
  */
-function compare(text, hash) {
+function compareBcrypt(text, hash) {
     return new Promise((resolve, reject) => {
         // Validate that both text and hash are strings
         if (typeof text !== "string" || typeof hash !== "string") {
@@ -70,6 +70,16 @@ function compare(text, hash) {
 }
 
 /**
+ * Checks if the given hash is a bcrypt hash.
+ *
+ * @param {string} hash - The hash to check.
+ * @returns {boolean} True if the hash is a bcrypt hash, false otherwise.
+ */
+function isBcryptHash(hash) {
+    return typeof hash === "string" && hash.startsWith("$2b$");
+}
+
+/**
  * Generates a SHA-256 hex digest for the provided input string.
  *
  * @param {string} input - The input to hash.
@@ -88,7 +98,8 @@ function sha256(input) {
 }
 
 module.exports = {
-    hash,
-    compare,
+    hashBcrypt,
+    compareBcrypt,
+    isBcryptHash,
     sha256,
 };

--- a/modules/digipog-transfer.js
+++ b/modules/digipog-transfer.js
@@ -1,0 +1,40 @@
+/**
+ * Read the sender identifier from the supported digipog transfer request fields.
+ * @param {Object} body - Request body.
+ * @returns {unknown}
+ */
+function getTransferFromValue(body) {
+    return body?.from ?? body?.fromUserId ?? body?.userId;
+}
+
+/**
+ * Normalize a digipog transfer sender reference into a stable shape.
+ * @param {unknown} rawFrom - Raw sender reference.
+ * @returns {{id: number, type: "user"|"pool"}|null}
+ */
+function normalizeTransferFrom(rawFrom) {
+    if (rawFrom === undefined || rawFrom === null || rawFrom === "") {
+        return null;
+    }
+
+    if (typeof rawFrom === "object") {
+        const type = rawFrom.type || "user";
+        const id = Number(rawFrom.id ?? rawFrom.userId ?? rawFrom.poolId);
+        if (!Number.isInteger(id) || id <= 0 || !["user", "pool"].includes(type)) {
+            return null;
+        }
+        return { id, type };
+    }
+
+    const id = Number(rawFrom);
+    if (!Number.isInteger(id) || id <= 0) {
+        return null;
+    }
+
+    return { id, type: "user" };
+}
+
+module.exports = {
+    getTransferFromValue,
+    normalizeTransferFrom,
+};

--- a/modules/socket-event-middleware.js
+++ b/modules/socket-event-middleware.js
@@ -56,8 +56,6 @@ async function createSocketContext(socket, event, args) {
     };
 
     socket.logger = logger.child(baseMeta);
-
-    socket.logger = socket.logger;
     socket.logEvent = (...logArgs) => logEvent(socket.logger, ...logArgs);
     socket.infoEvent = (...logArgs) => socket.logEvent("info", ...logArgs);
     socket.warnEvent = (...logArgs) => socket.logEvent("warn", ...logArgs);
@@ -201,9 +199,9 @@ function onSocketEvent(socket, event, ...middlewaresAndHandler) {
     const middlewares = middlewaresAndHandler;
 
     socket.on(event, async (...args) => {
-        const socketContext = await createSocketContext(socket, event, args);
-
         try {
+            const socketContext = await createSocketContext(socket, event, args);
+
             for (const middleware of middlewares) {
                 await middleware(socketContext, ...args);
             }

--- a/modules/socket-event-middleware.js
+++ b/modules/socket-event-middleware.js
@@ -3,6 +3,7 @@ const { dbGet } = require("@modules/database");
 const { getUserDataFromDb } = require("@services/user-service");
 const { userHasScope } = require("@modules/scope-resolver");
 const { handleSocketError } = require("@modules/socket-error-handler");
+const { getLogger, logEvent } = require("@modules/logger");
 const AuthError = require("@errors/auth-error");
 const ForbiddenError = require("@errors/forbidden-error");
 const ValidationError = require("@errors/validation-error");
@@ -45,7 +46,23 @@ async function getSocketUserData(socket, email) {
     return userRow ? getUserDataFromDb(userRow.id) : null;
 }
 
-function createSocketContext(socket, event, args) {
+async function createSocketContext(socket, event, args) {
+    const logger = await getLogger();
+    const baseMeta = {
+        socketId: socket.id,
+        event: event,
+        ip: socket.handshake?.address || socket.request?.socket?.remoteAddress,
+        session: JSON.stringify(socket.request.session),
+    };
+
+    socket.logger = logger.child(baseMeta);
+
+    socket.logger = socket.logger;
+    socket.logEvent = (...logArgs) => logEvent(socket.logger, ...logArgs);
+    socket.infoEvent = (...logArgs) => socket.logEvent("info", ...logArgs);
+    socket.warnEvent = (...logArgs) => socket.logEvent("warn", ...logArgs);
+    socket.errorEvent = (...logArgs) => socket.logEvent("error", ...logArgs);
+
     return {
         socket,
         socketUpdates: socket._socketUpdates,
@@ -184,7 +201,7 @@ function onSocketEvent(socket, event, ...middlewaresAndHandler) {
     const middlewares = middlewaresAndHandler;
 
     socket.on(event, async (...args) => {
-        const socketContext = createSocketContext(socket, event, args);
+        const socketContext = await createSocketContext(socket, event, args);
 
         try {
             for (const middleware of middlewares) {

--- a/modules/test-helpers/test-schema.sql
+++ b/modules/test-helpers/test-schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS "users" (
     "id"          INTEGER NOT NULL UNIQUE,
     "email"       TEXT    NOT NULL UNIQUE,
     "password"    TEXT,
-    "API"         TEXT,
+    "API"         TEXT    UNIQUE,
     "secret"      TEXT    NOT NULL UNIQUE,
     "tags"        TEXT,
     "digipogs"    INTEGER NOT NULL DEFAULT 0,

--- a/modules/test-helpers/test-schema.sql
+++ b/modules/test-helpers/test-schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS "users" (
     "id"          INTEGER NOT NULL UNIQUE,
     "email"       TEXT    NOT NULL UNIQUE,
     "password"    TEXT,
-    "API"         TEXT    NOT NULL UNIQUE,
+    "API"         TEXT,
     "secret"      TEXT    NOT NULL UNIQUE,
     "tags"        TEXT,
     "digipogs"    INTEGER NOT NULL DEFAULT 0,

--- a/modules/tests/crypto.spec.js
+++ b/modules/tests/crypto.spec.js
@@ -1,7 +1,7 @@
 // Use low salt rounds so bcrypt tests finish quickly
 process.env.SALT_ROUNDS = "4";
 
-const { hashBcrypt, compareBcrypt, sha256 } = require("@modules/crypto");
+const { hashBcrypt, compareBcrypt, isBcryptHash, sha256 } = require("@modules/crypto");
 
 describe("hashBcrypt()", () => {
     it("returns a bcrypt hash starting with $2b$", async () => {
@@ -37,6 +37,18 @@ describe("compareBcrypt()", () => {
 
     it("rejects when hash is not a string", async () => {
         await expect(compareBcrypt("text", 456)).rejects.toThrow("Both text and hash must be strings");
+    });
+});
+
+describe("isBcryptHash()", () => {
+    it("recognizes supported bcrypt prefixes", () => {
+        expect(isBcryptHash("$2a$10$abcdefghijklmnopqrstuuKdJ1tEFr1L1mZGhLeNYM8xA0xk1zYuG")).toBe(true);
+        expect(isBcryptHash("$2b$10$abcdefghijklmnopqrstuuKdJ1tEFr1L1mZGhLeNYM8xA0xk1zYuG")).toBe(true);
+        expect(isBcryptHash("$2y$10$abcdefghijklmnopqrstuuKdJ1tEFr1L1mZGhLeNYM8xA0xk1zYuG")).toBe(true);
+    });
+
+    it("rejects sha256-looking hashes", () => {
+        expect(isBcryptHash(sha256("api-key"))).toBe(false);
     });
 });
 

--- a/modules/tests/crypto.spec.js
+++ b/modules/tests/crypto.spec.js
@@ -1,42 +1,42 @@
 // Use low salt rounds so bcrypt tests finish quickly
 process.env.SALT_ROUNDS = "4";
 
-const { hash, compare, sha256 } = require("@modules/crypto");
+const { hashBcrypt, compareBcrypt, sha256 } = require("@modules/crypto");
 
-describe("hash()", () => {
+describe("hashBcrypt()", () => {
     it("returns a bcrypt hash starting with $2b$", async () => {
-        const result = await hash("password");
+        const result = await hashBcrypt("password");
         expect(result).toMatch(/^\$2b\$/);
     });
 
     it("rejects when given a non-string", async () => {
-        await expect(hash(123)).rejects.toThrow("Text to hash must be a string");
+        await expect(hashBcrypt(123)).rejects.toThrow("Text to hash must be a string");
     });
 
     it("rejects when given an empty string", async () => {
-        await expect(hash("")).rejects.toThrow("Text to hash must be provided");
+        await expect(hashBcrypt("")).rejects.toThrow("Text to hash must be provided");
     });
 });
 
-describe("compare()", () => {
+describe("compareBcrypt()", () => {
     it("returns true for matching text and hash", async () => {
-        const hashed = await hash("secret");
-        const result = await compare("secret", hashed);
+        const hashed = await hashBcrypt("secret");
+        const result = await compareBcrypt("secret", hashed);
         expect(result).toBe(true);
     });
 
     it("returns false for non-matching text and hash", async () => {
-        const hashed = await hash("secret");
-        const result = await compare("wrong", hashed);
+        const hashed = await hashBcrypt("secret");
+        const result = await compareBcrypt("wrong", hashed);
         expect(result).toBe(false);
     });
 
     it("rejects when text is not a string", async () => {
-        await expect(compare(123, "hash")).rejects.toThrow("Both text and hash must be strings");
+        await expect(compareBcrypt(123, "hash")).rejects.toThrow("Both text and hash must be strings");
     });
 
     it("rejects when hash is not a string", async () => {
-        await expect(compare("text", 456)).rejects.toThrow("Both text and hash must be strings");
+        await expect(compareBcrypt("text", 456)).rejects.toThrow("Both text and hash must be strings");
     });
 });
 

--- a/services/api-key-service.js
+++ b/services/api-key-service.js
@@ -1,0 +1,91 @@
+const { dbGet, dbGetAll, dbRun } = require("@modules/database");
+const { compareBcrypt, isBcryptHash, sha256 } = require("@modules/crypto");
+const { apiKeyCacheStore } = require("@stores/api-key-cache-store");
+
+/**
+ * Normalize a raw API key value from headers, query strings, or request bodies.
+ * @param {unknown} apiKey - Raw API key.
+ * @returns {string|null}
+ */
+function normalizeAPIKey(apiKey) {
+    if (typeof apiKey !== "string") {
+        return null;
+    }
+
+    const normalized = apiKey.trim();
+    return normalized || null;
+}
+
+/**
+ * Hash an API key for indexed storage and lookup.
+ * @param {string} apiKey - Plaintext API key.
+ * @returns {string}
+ */
+function hashAPIKey(apiKey) {
+    return sha256(apiKey);
+}
+
+/**
+ * Find a user by API key. SHA-256 keys are resolved by direct lookup; legacy
+ * bcrypt keys are checked only as a fallback and migrated after a successful match.
+ * @param {string} rawAPIKey - Plaintext API key.
+ * @returns {Promise<Object|null>}
+ */
+async function resolveAPIKey(rawAPIKey) {
+    const apiKey = normalizeAPIKey(rawAPIKey);
+    if (!apiKey) {
+        return null;
+    }
+
+    const cachedEmail = apiKeyCacheStore.get(apiKey);
+    if (cachedEmail) {
+        const apiKeyHash = hashAPIKey(apiKey);
+        const cachedUser = await dbGet("SELECT id, email, API FROM users WHERE email = ? AND API = ?", [cachedEmail, apiKeyHash]);
+        if (cachedUser) {
+            return { ...cachedUser, fromCache: true, migrated: false };
+        }
+        apiKeyCacheStore.delete(apiKey);
+    }
+
+    const apiKeyHash = hashAPIKey(apiKey);
+    const shaUser = await dbGet("SELECT id, email, API FROM users WHERE API = ?", [apiKeyHash]);
+    if (shaUser) {
+        apiKeyCacheStore.set(apiKey, shaUser.email);
+        return { ...shaUser, migrated: false };
+    }
+
+    const legacyUsers = await dbGetAll("SELECT id, email, API FROM users WHERE API IS NOT NULL AND API LIKE '$2%'");
+    for (const user of legacyUsers) {
+        if (!isBcryptHash(user.API)) {
+            continue;
+        }
+
+        const matches = await compareBcrypt(apiKey, user.API);
+        if (!matches) {
+            continue;
+        }
+
+        await dbRun("UPDATE users SET API = ? WHERE id = ? AND API = ?", [apiKeyHash, user.id, user.API]);
+        apiKeyCacheStore.set(apiKey, user.email);
+        return { ...user, API: apiKeyHash, migrated: true };
+    }
+
+    return null;
+}
+
+/**
+ * Resolve just the email for an API key.
+ * @param {string} apiKey - Plaintext API key.
+ * @returns {Promise<string|null>}
+ */
+async function getEmailFromAPIKey(apiKey) {
+    const user = await resolveAPIKey(apiKey);
+    return user ? user.email : null;
+}
+
+module.exports = {
+    normalizeAPIKey,
+    hashAPIKey,
+    resolveAPIKey,
+    getEmailFromAPIKey,
+};

--- a/services/auth-service.js
+++ b/services/auth-service.js
@@ -1,4 +1,4 @@
-const { compare, hash } = require("bcrypt");
+const { compareBcrypt, hashBcrypt } = require("@modules/crypto");
 const { dbGet, dbRun, dbGetAll } = require("@modules/database");
 const { privateKey, publicKey } = require("@modules/config");
 const { computeGlobalPermissionLevel, computeClassPermissionLevel, MANAGER_PERMISSIONS, STUDENT_PERMISSIONS } = require("@modules/permissions");
@@ -248,7 +248,7 @@ async function register(email, password, displayName) {
         throw new ConflictError("A user with that email or display name already exists.", { event: "auth.register.failed", reason: "user_exists" });
     }
 
-    const hashedPassword = await hash(password, 10);
+    const hashedPassword = await hashBcrypt(password);
     const userData = await normalizeUserData(
         await createUser({
             email,
@@ -293,7 +293,7 @@ async function login(email, password) {
         return invalidCredentials();
     }
 
-    const passwordMatches = await compare(password, userData.password);
+    const passwordMatches = await compareBcrypt(password, userData.password);
     if (passwordMatches) {
         return { tokens: await issueAuthTokens(userData), user: userData };
     } else {

--- a/services/auth-service.js
+++ b/services/auth-service.js
@@ -168,7 +168,6 @@ async function getUniqueDisplayName(displayName, email) {
  * @returns {Promise<Object>}
  */
 async function createUser({ email, password, displayName, verified }) {
-    const apiKey = crypto.randomBytes(64).toString("hex");
     const secret = crypto.randomBytes(256).toString("hex");
 
     const allUsers = await dbGetAll("SELECT * FROM users", []);

--- a/services/auth-service.js
+++ b/services/auth-service.js
@@ -178,7 +178,7 @@ async function createUser({ email, password, displayName, verified }) {
     const userId = await dbRun(`INSERT INTO users (email, password, API, secret, displayName, verified) VALUES (?, ?, ?, ?, ?, ?)`, [
         email,
         password || null,
-        apiKey,
+        null,
         secret,
         uniqueDisplayName,
         verified ? 1 : 0,

--- a/services/digipog-service.js
+++ b/services/digipog-service.js
@@ -1019,19 +1019,29 @@ async function transferDigipogs(transferData) {
 
         let fromAccount;
         if (from.type === "user") {
-            fromAccount = await dbGet("SELECT * FROM users WHERE id = ?", [from.id]);
+            fromAccount = await dbGet("SELECT id, digipogs, pin FROM users WHERE id = ?", [from.id]);
             if (!fromAccount) {
                 recordAttempt(accountId, false);
                 return { success: false, message: "Sender account not found." };
             }
         } else {
-            fromAccount = await dbGet("SELECT * FROM digipog_pools WHERE id = ?", [from.id]);
-            const poolUser = await dbGet("SELECT user_id FROM digipog_pool_users WHERE pool_id = ? AND owner = 1", [from.id]);
+            fromAccount = await dbGet("SELECT id, amount FROM digipog_pools WHERE id = ?", [from.id]);
             if (!fromAccount) {
                 recordAttempt(accountId, false);
                 return { success: false, message: "Sender pool not found." };
             }
-            const poolOwner = await dbGet("SELECT pin FROM users WHERE id = ?", [poolUser.user_id]);
+            const poolOwner = await dbGet(
+                `SELECT u.pin
+                 FROM digipog_pool_users dpu
+                 JOIN users u ON u.id = dpu.user_id
+                 WHERE dpu.pool_id = ? AND dpu.owner = 1
+                 LIMIT 1`,
+                [from.id]
+            );
+            if (!poolOwner) {
+                recordAttempt(accountId, false);
+                return { success: false, message: "Sender pool owner not found." };
+            }
             fromAccount.pin = poolOwner.pin;
         }
 
@@ -1057,13 +1067,13 @@ async function transferDigipogs(transferData) {
 
         let toAccount;
         if (to.type === "user") {
-            toAccount = await dbGet("SELECT * FROM users WHERE id = ?", [to.id]);
+            toAccount = await dbGet("SELECT id FROM users WHERE id = ?", [to.id]);
             if (!toAccount) {
                 recordAttempt(accountId, false);
                 return { success: false, message: "Recipient account not found." };
             }
         } else {
-            toAccount = await dbGet("SELECT * FROM digipog_pools WHERE id = ?", [to.id]);
+            toAccount = await dbGet("SELECT id FROM digipog_pools WHERE id = ?", [to.id]);
             if (!toAccount) {
                 recordAttempt(accountId, false);
                 return { success: false, message: "Recipient pool not found." };
@@ -1082,7 +1092,7 @@ async function transferDigipogs(transferData) {
             } else {
                 await dbRun("UPDATE digipog_pools SET amount = amount + ? WHERE id = ?", [taxedAmount, to.id]);
             }
-            const devPool = await dbGet("SELECT * FROM digipog_pools WHERE id = ?", [0]);
+            const devPool = await dbGet("SELECT id FROM digipog_pools WHERE id = ?", [0]);
             if (devPool) await dbRun("UPDATE digipog_pools SET amount = amount + ? WHERE id = ?", [taxAmount, 0]);
             await dbRun("COMMIT");
         } catch (err) {

--- a/services/digipog-service.js
+++ b/services/digipog-service.js
@@ -2,7 +2,7 @@ const { dbGetAll, dbGet, dbRun } = require("@modules/database");
 const { SCOPES, filterScopesByDomain, parseScopesField, TEACHER_PERMISSIONS } = require("@modules/permissions");
 const { getClassIDFromCode } = require("@services/classroom-service");
 const { getGlobalPermissionLevelForUser } = require("@modules/scope-resolver");
-const { compare } = require("@modules/crypto");
+const { compareBcrypt } = require("@modules/crypto");
 const { rateLimit } = require("@modules/config");
 const AppError = require("@errors/app-error");
 
@@ -1040,7 +1040,7 @@ async function transferDigipogs(transferData) {
             return { success: false, message: "Account PIN not configured." };
         }
 
-        const isPinValid = await compare(String(pin), fromAccount.pin);
+        const isPinValid = await compareBcrypt(String(pin), fromAccount.pin);
         if (!isPinValid) {
             recordAttempt(accountId, false);
             return { success: false, message: "Invalid PIN." };

--- a/services/socket-updates-service.js
+++ b/services/socket-updates-service.js
@@ -161,6 +161,10 @@ async function advancedEmitToClass(event, classId, options, ...data) {
  */
 async function setClassOfApiSockets(api, classId) {
     try {
+        if (!api) {
+            return;
+        }
+
         const sockets = await io.in(`api-${api}`).fetchSockets();
         for (let socket of sockets) {
             // Ensure the socket has a session before continuing

--- a/services/tests/api-key-service.spec.js
+++ b/services/tests/api-key-service.spec.js
@@ -1,0 +1,73 @@
+const { createTestDb } = require("@test-helpers/db");
+
+let mockDatabase;
+
+jest.mock("@modules/database", () => ({
+    get database() {
+        return mockDatabase && mockDatabase.db;
+    },
+    dbGet: (...args) => mockDatabase.dbGet(...args),
+    dbRun: (...args) => mockDatabase.dbRun(...args),
+    dbGetAll: (...args) => mockDatabase.dbGetAll(...args),
+}));
+
+const { hashBcrypt, sha256 } = require("@modules/crypto");
+const { apiKeyCacheStore } = require("@stores/api-key-cache-store");
+const { resolveAPIKey } = require("@services/api-key-service");
+
+beforeAll(async () => {
+    mockDatabase = await createTestDb();
+});
+
+afterEach(async () => {
+    await mockDatabase.reset();
+    apiKeyCacheStore.clear();
+});
+
+afterAll(async () => {
+    await mockDatabase.close();
+});
+
+async function seedUser(apiHash, email = "api-key-user@test.com") {
+    return mockDatabase.dbRun("INSERT INTO users (email, password, API, secret, displayName, digipogs, verified) VALUES (?, ?, ?, ?, ?, ?, ?)", [
+        email,
+        "hashed-password",
+        apiHash,
+        `${email}-secret`,
+        email,
+        0,
+        1,
+    ]);
+}
+
+describe("resolveAPIKey()", () => {
+    it("resolves sha256 API keys with a direct lookup", async () => {
+        const apiKey = "sha-key";
+        const userId = await seedUser(sha256(apiKey));
+
+        const user = await resolveAPIKey(apiKey);
+
+        expect(user).toEqual(expect.objectContaining({ id: userId, email: "api-key-user@test.com", migrated: false }));
+    });
+
+    it("migrates a matching bcrypt API key to sha256", async () => {
+        const apiKey = "legacy-api-key";
+        const legacyHash = await hashBcrypt(apiKey);
+        const userId = await seedUser(legacyHash, "legacy-api-key@test.com");
+
+        const user = await resolveAPIKey(apiKey);
+
+        expect(user).toEqual(expect.objectContaining({ id: userId, email: "legacy-api-key@test.com", migrated: true }));
+        const row = await mockDatabase.dbGet("SELECT API FROM users WHERE id = ?", [userId]);
+        expect(row.API).toBe(sha256(apiKey));
+    });
+
+    it("does not trust a stale cache entry after the stored hash changes", async () => {
+        await seedUser(sha256("new-key"), "rotated-api-key@test.com");
+        apiKeyCacheStore.set("old-key", "rotated-api-key@test.com");
+
+        const user = await resolveAPIKey("old-key");
+
+        expect(user).toBeNull();
+    });
+});

--- a/services/tests/digipog-service.spec.js
+++ b/services/tests/digipog-service.spec.js
@@ -708,7 +708,8 @@ describe("transferDigipogs()", () => {
     let hashedPin;
 
     beforeAll(async () => {
-        hashedPin = await bcrypt.hash("1234", 10);
+        const { hashBcrypt } = require("@modules/crypto");
+        hashedPin = await hashBcrypt("1234");
     });
 
     it("transfers between users with 10% tax", async () => {

--- a/services/tests/user-service.spec.js
+++ b/services/tests/user-service.spec.js
@@ -107,7 +107,7 @@ jest.mock("@services/student-service", () => ({
 const fs = require("fs");
 const realReadFileSync = fs.readFileSync;
 const bcrypt = require("bcrypt");
-const { hash } = require("@modules/crypto");
+const { hashBcrypt, compareBcrypt } = require("@modules/crypto");
 const { sendMail } = require("@modules/mail");
 const { apiKeyCacheStore } = require("@stores/api-key-cache-store");
 const { classStateStore } = require("@services/classroom-service");
@@ -311,7 +311,7 @@ describe("resetPassword()", () => {
         const row = await mockDatabase.dbGet("SELECT password FROM users WHERE id = ?", [seeded.id]);
         expect(row.password).not.toBe("NewPassword1!");
         expect(row.password.startsWith("$2b$")).toBe(true);
-        const matches = await bcrypt.compare("NewPassword1!", row.password);
+        const matches = await compareBcrypt("NewPassword1!", row.password);
         expect(matches).toBe(true);
     });
 
@@ -328,30 +328,30 @@ describe("updatePassword()", () => {
         expect(result).toBe(true);
 
         const row = await mockDatabase.dbGet("SELECT password FROM users WHERE id = ?", [seeded.id]);
-        const matches = await bcrypt.compare("NewPassword1!", row.password);
+        const matches = await compareBcrypt("NewPassword1!", row.password);
         expect(matches).toBe(true);
     });
 
     it("updates an existing password when the old password matches", async () => {
-        const hashedPassword = await bcrypt.hash("OldPassword1!", 10);
+        const hashedPassword = await hashBcrypt("OldPassword1!");
         const seeded = await seedUser({ password: hashedPassword });
 
         await updatePassword(seeded.id, "OldPassword1!", "NewPassword1!");
 
         const row = await mockDatabase.dbGet("SELECT password FROM users WHERE id = ?", [seeded.id]);
-        const matches = await bcrypt.compare("NewPassword1!", row.password);
+        const matches = await compareBcrypt("NewPassword1!", row.password);
         expect(matches).toBe(true);
     });
 
     it("requires the current password when one already exists", async () => {
-        const hashedPassword = await bcrypt.hash("OldPassword1!", 10);
+        const hashedPassword = await hashBcrypt("OldPassword1!");
         const seeded = await seedUser({ password: hashedPassword });
 
         await expect(updatePassword(seeded.id, null, "NewPassword1!")).rejects.toThrow(AppError);
     });
 
     it("throws AuthError when the current password is incorrect", async () => {
-        const hashedPassword = await bcrypt.hash("OldPassword1!", 10);
+        const hashedPassword = await hashBcrypt("OldPassword1!");
         const seeded = await seedUser({ password: hashedPassword });
 
         await expect(updatePassword(seeded.id, "WrongPassword1!", "NewPassword1!")).rejects.toThrow(AuthError);
@@ -377,7 +377,7 @@ describe("regenerateAPIKey()", () => {
         const row = await mockDatabase.dbGet("SELECT API FROM users WHERE id = ?", [seeded.id]);
         expect(row.API).not.toBe("oldapi");
         expect(row.API).not.toBe(newKey);
-        const matches = await bcrypt.compare(newKey, row.API);
+        const matches = await compareBcrypt(newKey, row.API);
         expect(matches).toBe(true);
     });
 
@@ -426,7 +426,7 @@ describe("resetPin()", () => {
 
         const row = await mockDatabase.dbGet("SELECT pin FROM users WHERE id = ?", [seeded.id]);
         expect(row.pin).not.toBe("5678");
-        const matches = await bcrypt.compare("5678", row.pin);
+        const matches = await compareBcrypt("5678", row.pin);
         expect(matches).toBe(true);
     });
 });
@@ -450,28 +450,28 @@ describe("updatePin()", () => {
         await updatePin(seeded.id, null, "1234");
 
         const row = await mockDatabase.dbGet("SELECT pin FROM users WHERE id = ?", [seeded.id]);
-        const matches = await bcrypt.compare("1234", row.pin);
+        const matches = await compareBcrypt("1234", row.pin);
         expect(matches).toBe(true);
     });
 
     it("updates pin when old pin matches", async () => {
-        const hashedOld = await hash("1111");
+        const hashedOld = await hashBcrypt("1111");
         const seeded = await seedUser({ pin: hashedOld });
         await updatePin(seeded.id, "1111", "2222");
 
         const row = await mockDatabase.dbGet("SELECT pin FROM users WHERE id = ?", [seeded.id]);
-        const matches = await bcrypt.compare("2222", row.pin);
+        const matches = await compareBcrypt("2222", row.pin);
         expect(matches).toBe(true);
     });
 
     it("throws AuthError when old pin is incorrect", async () => {
-        const hashedOld = await hash("1111");
+        const hashedOld = await hashBcrypt("1111");
         const seeded = await seedUser({ pin: hashedOld });
         await expect(updatePin(seeded.id, "9999", "2222")).rejects.toThrow(AuthError);
     });
 
     it("throws AppError when old pin is missing but user has a pin", async () => {
-        const hashedOld = await hash("1111");
+        const hashedOld = await hashBcrypt("1111");
         const seeded = await seedUser({ pin: hashedOld });
         await expect(updatePin(seeded.id, null, "2222")).rejects.toThrow(AppError);
     });
@@ -497,14 +497,14 @@ describe("verifyPin()", () => {
     });
 
     it("returns true when pin matches", async () => {
-        const hashedPin = await hash("5555");
+        const hashedPin = await hashBcrypt("5555");
         const seeded = await seedUser({ pin: hashedPin });
         const result = await verifyPin(seeded.id, "5555");
         expect(result).toBe(true);
     });
 
     it("throws AuthError when pin is incorrect", async () => {
-        const hashedPin = await hash("5555");
+        const hashedPin = await hashBcrypt("5555");
         const seeded = await seedUser({ pin: hashedPin });
         await expect(verifyPin(seeded.id, "0000")).rejects.toThrow(AuthError);
     });

--- a/services/tests/user-service.spec.js
+++ b/services/tests/user-service.spec.js
@@ -107,7 +107,7 @@ jest.mock("@services/student-service", () => ({
 const fs = require("fs");
 const realReadFileSync = fs.readFileSync;
 const bcrypt = require("bcrypt");
-const { hashBcrypt, compareBcrypt } = require("@modules/crypto");
+const { hashBcrypt, compareBcrypt, sha256 } = require("@modules/crypto");
 const { sendMail } = require("@modules/mail");
 const { apiKeyCacheStore } = require("@stores/api-key-cache-store");
 const { classStateStore } = require("@services/classroom-service");
@@ -367,7 +367,7 @@ describe("regenerateAPIKey()", () => {
         await expect(regenerateAPIKey(99999)).rejects.toThrow(NotFoundError);
     });
 
-    it("returns a new plaintext API key and stores a hash", async () => {
+    it("returns a new plaintext API key and stores a sha256 hash", async () => {
         const seeded = await seedUser({ email: "apiuser@test.com", API: "oldapi" });
         const newKey = await regenerateAPIKey(seeded.id);
 
@@ -377,8 +377,7 @@ describe("regenerateAPIKey()", () => {
         const row = await mockDatabase.dbGet("SELECT API FROM users WHERE id = ?", [seeded.id]);
         expect(row.API).not.toBe("oldapi");
         expect(row.API).not.toBe(newKey);
-        const matches = await compareBcrypt(newKey, row.API);
-        expect(matches).toBe(true);
+        expect(row.API).toBe(sha256(newKey));
     });
 
     it("invalidates the API key cache", async () => {

--- a/services/user-service.js
+++ b/services/user-service.js
@@ -1,6 +1,5 @@
 const handlebars = require("handlebars");
 const fs = require("fs");
-const bcrypt = require("bcrypt");
 const crypto = require("crypto");
 const AppError = require("@errors/app-error");
 const NotFoundError = require("@errors/not-found-error");
@@ -18,7 +17,7 @@ const { managerUpdate, userUpdateSocket } = require("@services/socket-updates-se
 const { endClass } = require("@services/class-service");
 const { deleteClassrooms } = require("@services/class-service");
 const { deleteCustomPolls } = require("@services/poll-service");
-const { hash } = require("@modules/crypto");
+const { hashBcrypt, compareBcrypt } = require("@modules/crypto");
 const { requireInternalParam } = require("@modules/error-wrapper");
 const { assertValidPassword } = require("@modules/password-validation");
 const { getEmailFromId } = require("@services/student-service");
@@ -115,7 +114,7 @@ async function resetPin(newPin, token) {
         });
     }
 
-    const hashedPin = await hash(String(newPin));
+    const hashedPin = await hashBcrypt(String(newPin));
     await dbRun("UPDATE users SET pin = ? WHERE id = ?", [hashedPin, user.id]);
 }
 
@@ -141,7 +140,7 @@ async function updatePin(userId, oldPin, newPin) {
     // If user already has a PIN, verify the old one matches
     if (user.pin) {
         requireInternalParam(oldPin, "oldPin");
-        const oldPinMatches = await bcrypt.compare(String(oldPin), user.pin);
+        const oldPinMatches = await compareBcrypt(String(oldPin), user.pin);
         if (!oldPinMatches) {
             const AuthError = require("@errors/auth-error");
             throw new AuthError("Current PIN is incorrect.", {
@@ -151,7 +150,7 @@ async function updatePin(userId, oldPin, newPin) {
         }
     }
 
-    const hashedPin = await hash(String(newPin));
+    const hashedPin = await hashBcrypt(String(newPin));
     await dbRun("UPDATE users SET pin = ? WHERE id = ?", [hashedPin, userId]);
 }
 
@@ -181,7 +180,7 @@ async function verifyPin(userId, pin) {
         });
     }
 
-    const pinMatches = await bcrypt.compare(String(pin), user.pin);
+    const pinMatches = await compareBcrypt(String(pin), user.pin);
     if (!pinMatches) {
         const AuthError = require("@errors/auth-error");
         throw new AuthError("PIN is incorrect.", {
@@ -338,7 +337,7 @@ async function resetPassword(password, token) {
         });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashedPassword = await hashBcrypt(password);
     await dbRun("UPDATE users SET password = ? WHERE id = ?", [hashedPassword, user.id]);
     return true;
 }
@@ -366,7 +365,7 @@ async function updatePassword(userId, oldPassword, newPassword) {
     if (user.password) {
         requireInternalParam(oldPassword, "oldPassword");
 
-        const oldPasswordMatches = await bcrypt.compare(oldPassword, user.password);
+        const oldPasswordMatches = await compareBcrypt(oldPassword, user.password);
         if (!oldPasswordMatches) {
             const AuthError = require("@errors/auth-error");
             throw new AuthError("Current password is incorrect.", {
@@ -376,7 +375,7 @@ async function updatePassword(userId, oldPassword, newPassword) {
         }
     }
 
-    const hashedPassword = await bcrypt.hash(newPassword, 10);
+    const hashedPassword = await hashBcrypt(newPassword);
     await dbRun("UPDATE users SET password = ? WHERE id = ?", [hashedPassword, userId]);
     return true;
 }
@@ -398,8 +397,7 @@ async function regenerateAPIKey(userId) {
     }
 
     // Generate a new API key for the user
-    const apiKey = crypto.randomBytes(32).toString("hex");
-    const hashedAPIKey = await hash(apiKey);
+    const hashedAPIKey = await sha256(apiKey);
     await dbRun("UPDATE users SET API = ? WHERE id = ?", [hashedAPIKey, userId]);
 
     // Invalidate the cache for the user's email
@@ -453,7 +451,7 @@ async function getEmailFromAPIKey(api) {
                     if (err) throw err;
                     let userData = null;
                     for (const user of users) {
-                        if (user.API && (await bcrypt.compare(api, user.API))) {
+                        if (user.API && (await compareBcrypt(api, user.API))) {
                             userData = user;
                             break;
                         }

--- a/services/user-service.js
+++ b/services/user-service.js
@@ -18,6 +18,7 @@ const { endClass } = require("@services/class-service");
 const { deleteClassrooms } = require("@services/class-service");
 const { deleteCustomPolls } = require("@services/poll-service");
 const { hashBcrypt, compareBcrypt } = require("@modules/crypto");
+const { hashAPIKey, getEmailFromAPIKey: resolveEmailFromAPIKey } = require("@services/api-key-service");
 const { requireInternalParam } = require("@modules/error-wrapper");
 const { assertValidPassword } = require("@modules/password-validation");
 const { getEmailFromId } = require("@services/student-service");
@@ -396,14 +397,13 @@ async function regenerateAPIKey(userId) {
         });
     }
 
-    // Generate a new API key for the user
-    const hashedAPIKey = await sha256(apiKey);
+    const apiKey = crypto.randomBytes(32).toString("hex");
+    const hashedAPIKey = hashAPIKey(apiKey);
     await dbRun("UPDATE users SET API = ? WHERE id = ?", [hashedAPIKey, userId]);
 
     // Invalidate the cache for the user's email
-    const email = await getEmailFromId(userId);
-    if (email) {
-        apiKeyCacheStore.invalidateByEmail(email);
+    if (user.email) {
+        apiKeyCacheStore.invalidateByEmail(user.email);
     } else {
         apiKeyCacheStore.clear();
     }
@@ -442,34 +442,8 @@ async function getEmailFromAPIKey(api) {
     try {
         if (!api) return { error: "Missing API key" };
 
-        const cachedEmail = apiKeyCacheStore.get(api);
-        if (cachedEmail) return cachedEmail;
-
-        let user = await new Promise((resolve, reject) => {
-            database.all("SELECT * FROM users", [], async (err, users) => {
-                try {
-                    if (err) throw err;
-                    let userData = null;
-                    for (const user of users) {
-                        if (user.API && (await compareBcrypt(api, user.API))) {
-                            userData = user;
-                            break;
-                        }
-                    }
-                    if (!userData) {
-                        resolve({ error: "Not a valid API key" });
-                        return;
-                    }
-                    resolve(userData);
-                } catch (err) {
-                    reject(err);
-                }
-            });
-        });
-
-        if (user.error) return user;
-        apiKeyCacheStore.set(api, user.email);
-        return user.email;
+        const email = await resolveEmailFromAPIKey(api);
+        return email || { error: "Not a valid API key" };
     } catch (err) {
         return err;
     }

--- a/sockets/backwards-compat.js
+++ b/sockets/backwards-compat.js
@@ -6,10 +6,9 @@
  * emits a deprecation warning so developers know to migrate.
  */
 
-const { dbGetAll } = require("@modules/database");
-const { compareBcrypt } = require("@modules/crypto");
 const { verifyToken } = require("@services/auth-service");
 const { getUserDataFromDb } = require("@services/user-service");
+const { resolveAPIKey } = require("@services/api-key-service");
 const { handleSocketError } = require("@modules/socket-error-handler");
 const { finalizeAuthentication } = require("./middleware/api");
 
@@ -37,21 +36,12 @@ module.exports = {
                     return socket.emit("error", "Invalid API key format.");
                 }
 
-                // Find the user whose hashed API key matches the provided plaintext key.
-                // Limit to users with an API key set and only fetch needed columns.
-                const users = await dbGetAll("SELECT id, email, API, tags, displayName FROM users WHERE API IS NOT NULL");
-                let userData = null;
-                for (const user of users) {
-                    if (user.API && (await compareBcrypt(apiKey, user.API))) {
-                        userData = await getUserDataFromDb(user.id);
-                        break;
-                    }
-                }
-
-                if (!userData) {
+                const apiKeyUser = await resolveAPIKey(apiKey);
+                if (!apiKeyUser) {
                     return socket.emit("error", "Invalid API key.");
                 }
 
+                const userData = await getUserDataFromDb(apiKeyUser.id);
                 finalizeAuthentication(socket, userData, socketUpdates, true);
 
                 socket.emit("deprecationWarning", {

--- a/sockets/backwards-compat.js
+++ b/sockets/backwards-compat.js
@@ -7,7 +7,7 @@
  */
 
 const { dbGetAll } = require("@modules/database");
-const { compare } = require("@modules/crypto");
+const { compareBcrypt } = require("@modules/crypto");
 const { verifyToken } = require("@services/auth-service");
 const { getUserDataFromDb } = require("@services/user-service");
 const { handleSocketError } = require("@modules/socket-error-handler");
@@ -42,7 +42,7 @@ module.exports = {
                 const users = await dbGetAll("SELECT id, email, API, tags, displayName FROM users WHERE API IS NOT NULL");
                 let userData = null;
                 for (const user of users) {
-                    if (user.API && (await compare(apiKey, user.API))) {
+                    if (user.API && (await compareBcrypt(apiKey, user.API))) {
                         userData = await getUserDataFromDb(user.id);
                         break;
                     }

--- a/sockets/class.js
+++ b/sockets/class.js
@@ -175,7 +175,7 @@ module.exports = {
             try {
                 const classId = await socketContext.resolveClassId();
                 const userId = await getIdFromEmail(email);
-                classKickStudent(userId, classId);
+                await classKickStudent(userId, classId);
                 advancedEmitToClass("leaveSound", classId, {});
             } catch (err) {
                 handleSocketError(err, socket, "classKickStudent");
@@ -189,21 +189,16 @@ module.exports = {
          */
         onSocketEvent(socket, "classRemoveFromSession", hasClassScope(SCOPES.CLASS.STUDENTS.KICK), async (socketContext, userId) => {
             try {
-                logger.log("info", `[classRemoveFromSession] ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`);
-                logger.log("info", `[classRemoveFromSession] userId=(${userId})`);
-
-                logEvent(
-                    logger,
-                    "info",
+                socketContext.infoEvent(
                     "classRemoveFromSession",
                     `ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`
                 );
-                logEvent(logger, "info", "classRemoveFromSession", `userId=(${userId})`);
+                socketContext.infoEvent("classRemoveFromSession", `userId=(${userId})`);
 
                 const classId = await socketContext.resolveClassId();
-                classKickStudent(userId, classId, { exitRoom: false, ban: false });
+                await classKickStudent(userId, classId, { exitRoom: false, ban: false });
             } catch (err) {
-                logger.log("error", err.stack);
+                handleSocketError(err, socket, "classRemoveFromSession");
             }
         });
 

--- a/sockets/class.js
+++ b/sockets/class.js
@@ -189,6 +189,14 @@ module.exports = {
                 logger.log("info", `[classRemoveFromSession] ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`);
                 logger.log("info", `[classRemoveFromSession] userId=(${userId})`);
 
+                logEvent(
+                    logger,
+                    "info",
+                    "classRemoveFromSession",
+                    `ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`
+                );
+                logEvent(logger, "info", "classRemoveFromSession", `userId=(${userId})`);
+
                 const classId = await socketContext.resolveClassId();
                 classKickStudent(userId, classId, { exitRoom: false, ban: false });
             } catch (err) {

--- a/sockets/class.js
+++ b/sockets/class.js
@@ -71,6 +71,9 @@ module.exports = {
         socket.on("getActiveClass", () => {
             try {
                 const api = socket.request.session.api;
+                if (!api) {
+                    return;
+                }
 
                 for (const email in classStateStore.getAllUsers()) {
                     const user = classStateStore.getAllUsers()[email];

--- a/sockets/class.js
+++ b/sockets/class.js
@@ -189,11 +189,11 @@ module.exports = {
          */
         onSocketEvent(socket, "classRemoveFromSession", hasClassScope(SCOPES.CLASS.STUDENTS.KICK), async (socketContext, userId) => {
             try {
-                socketContext.infoEvent(
+                socketContext.socket.infoEvent(
                     "classRemoveFromSession",
                     `ip=(${socket.handshake.address}) session=(${JSON.stringify(socket.request.session)})`
                 );
-                socketContext.infoEvent("classRemoveFromSession", `userId=(${userId})`);
+                socketContext.socket.infoEvent("classRemoveFromSession", `userId=(${userId})`);
 
                 const classId = await socketContext.resolveClassId();
                 await classKickStudent(userId, classId, { exitRoom: false, ban: false });

--- a/sockets/middleware/api.js
+++ b/sockets/middleware/api.js
@@ -3,7 +3,7 @@ const { database } = require("@modules/database");
 const { createStudentFromUserData, getIdFromEmail } = require("@services/student-service");
 const { getUserClass, getUserDataFromDb } = require("@services/user-service");
 const { classKickStudent } = require("@services/class-service");
-const { compare } = require("@modules/crypto");
+const { compareBcrypt } = require("@modules/crypto");
 const { verifyToken } = require("@services/auth-service");
 const { socketStateStore } = require("@stores/socket-state-store");
 const { apiKeyCacheStore } = require("@stores/api-key-cache-store");
@@ -184,7 +184,7 @@ module.exports = {
                                 // Compare the provided API key with each user's hashed API key
                                 let userData = null;
                                 for (const user of users) {
-                                    if (user.API && (await compare(api, user.API))) {
+                                    if (user.API && *(await compareBcrypt(api, user.API))) {
                                         userData = user;
                                         break;
                                     }

--- a/sockets/middleware/api.js
+++ b/sockets/middleware/api.js
@@ -3,10 +3,9 @@ const { database } = require("@modules/database");
 const { createStudentFromUserData, getIdFromEmail } = require("@services/student-service");
 const { getUserClass, getUserDataFromDb } = require("@services/user-service");
 const { classKickStudent } = require("@services/class-service");
-const { compareBcrypt } = require("@modules/crypto");
+const { resolveAPIKey } = require("@services/api-key-service");
 const { verifyToken } = require("@services/auth-service");
 const { socketStateStore } = require("@stores/socket-state-store");
-const { apiKeyCacheStore } = require("@stores/api-key-cache-store");
 const { addUserSocketUpdate, removeUserSocketUpdate } = require("../init");
 
 const { handleSocketError } = require("@modules/socket-error-handler");
@@ -151,64 +150,13 @@ module.exports = {
 
             // Try API key authentication first
             if (api) {
-                // Fast-fail: API keys are 64-char hex strings. Reject anything
-                // that doesn't match the format before running any bcrypt comparisons.
-                if (!/^[0-9a-f]{64}$/.test(api)) {
+                const apiKeyUser = await resolveAPIKey(api);
+                if (!apiKeyUser) {
                     throw "Not a valid API key";
                 }
 
-                // Check the in-memory cache first to avoid bcrypt comparisons on repeat connections.
-                const cachedEmail = apiKeyCacheStore.get(api);
-                if (cachedEmail) {
-                    const userData = await new Promise((resolve, reject) => {
-                        database.get("SELECT id FROM users WHERE email = ?", [cachedEmail], async (err, row) => {
-                            try {
-                                if (err) return reject(err);
-                                if (!row) return reject("User not found");
-                                resolve(await getUserDataFromDb(row.id));
-                            } catch (error) {
-                                reject(error);
-                            }
-                        });
-                    });
-                    finalizeAuthentication(socket, userData, socketUpdates, true);
-                } else {
-                    await new Promise((resolve, reject) => {
-                        // Look up the user by comparing API key hash.
-                        // Only fetch users that actually have an API key set to avoid
-                        // pulling sensitive columns (password hash, secret) for every user.
-                        database.all("SELECT id, email, API, displayName FROM users WHERE API IS NOT NULL", [], async (err, users) => {
-                            try {
-                                if (err) throw err;
-
-                                // Compare the provided API key with each user's hashed API key
-                                let userData = null;
-                                for (const user of users) {
-                                    if (user.API && *(await compareBcrypt(api, user.API))) {
-                                        userData = user;
-                                        break;
-                                    }
-                                }
-
-                                if (!userData) {
-                                    throw "Not a valid API key";
-                                }
-
-                                userData = await getUserDataFromDb(userData.id);
-
-                                // Cache the result for future connections
-                                apiKeyCacheStore.set(api, userData.email);
-
-                                finalizeAuthentication(socket, userData, socketUpdates, true);
-                                resolve();
-                            } catch (err) {
-                                reject(err);
-                            }
-                        });
-                    }).catch((err) => {
-                        throw err;
-                    });
-                }
+                const userData = await getUserDataFromDb(apiKeyUser.id);
+                finalizeAuthentication(socket, userData, socketUpdates, true);
             } else if (authorization) {
                 // Try JWT access token authentication
                 await new Promise((resolve, reject) => {

--- a/sockets/middleware/authentication.js
+++ b/sockets/middleware/authentication.js
@@ -1,5 +1,4 @@
-const { database } = require("@modules/database");
-const { compareBcrypt } = require("@modules/crypto");
+const { resolveAPIKey } = require("@services/api-key-service");
 const { classStateStore } = require("@services/classroom-service");
 const authService = require("@services/auth-service");
 
@@ -58,20 +57,8 @@ module.exports = {
 
                     next();
                 } else if (api) {
-                    // Get all users and compare the API key hash
-                    database.all("SELECT id, email, API FROM users", [], async (err, users) => {
-                        try {
-                            if (err) throw err;
-
-                            // Compare the provided API key with each user's hashed API key
-                            let matchedUser = null;
-                            for (const user of users) {
-                                if (user.API && (await compareBcrypt(api, user.API))) {
-                                    matchedUser = user;
-                                    break;
-                                }
-                            }
-
+                    resolveAPIKey(api)
+                        .then((matchedUser) => {
                             if (!matchedUser) {
                                 next(new Error("Not a valid API key"));
                                 return;
@@ -83,11 +70,11 @@ module.exports = {
                             socket.request.session.classId = null;
 
                             next();
-                        } catch (err) {
+                        })
+                        .catch((err) => {
                             handleSocketError(err, socket, "authentication:api");
                             next(err);
-                        }
-                    });
+                        });
                 } else {
                     next(new Error("Missing authentication credentials"));
                 }

--- a/sockets/middleware/authentication.js
+++ b/sockets/middleware/authentication.js
@@ -1,5 +1,5 @@
 const { database } = require("@modules/database");
-const { compare } = require("@modules/crypto");
+const { compareBcrypt } = require("@modules/crypto");
 const { classStateStore } = require("@services/classroom-service");
 const authService = require("@services/auth-service");
 
@@ -66,7 +66,7 @@ module.exports = {
                             // Compare the provided API key with each user's hashed API key
                             let matchedUser = null;
                             for (const user of users) {
-                                if (user.API && (await compare(api, user.API))) {
+                                if (user.API && (await compareBcrypt(api, user.API))) {
                                     matchedUser = user;
                                     break;
                                 }

--- a/sockets/middleware/rate-limiter.js
+++ b/sockets/middleware/rate-limiter.js
@@ -46,7 +46,7 @@ module.exports = {
                 const timeFrame = 1000; // 1 Second
                 const limit =
                     computeGlobalPermissionLevel(getUserScopes(userData || socket.request.session).global) >= TEACHER_PERMISSIONS ? 100 : 30;
-                const identifier = String(userData?.id ?? socket.request.session.userId);
+                const identifier = String(userData?.id ?? socket.request.session.userId ?? email ?? socket.id);
                 const userRequests = socketStateStore.getUserRateLimits(identifier, true);
                 userRequests[event] = userRequests[event] || [];
                 while (userRequests[event].length && currentTime - userRequests[event][0] > timeFrame) {

--- a/sockets/middleware/rate-limiter.js
+++ b/sockets/middleware/rate-limiter.js
@@ -46,7 +46,8 @@ module.exports = {
                 const timeFrame = 1000; // 1 Second
                 const limit =
                     computeGlobalPermissionLevel(getUserScopes(userData || socket.request.session).global) >= TEACHER_PERMISSIONS ? 100 : 30;
-                const userRequests = socketStateStore.getUserRateLimits(email, true);
+                const identifier = String(userData?.id ?? socket.request.session.userId);
+                const userRequests = socketStateStore.getUserRateLimits(identifier, true);
                 userRequests[event] = userRequests[event] || [];
                 while (userRequests[event].length && currentTime - userRequests[event][0] > timeFrame) {
                     userRequests[event].shift();

--- a/sockets/tests/backwards-compat.spec.js
+++ b/sockets/tests/backwards-compat.spec.js
@@ -1,10 +1,12 @@
 jest.mock("@services/auth-service");
 jest.mock("@modules/crypto");
 jest.mock("@modules/database");
+jest.mock("@services/api-key-service");
 
 const { run: backwardsCompatRun } = require("../backwards-compat");
 const { verifyToken } = require("@services/auth-service");
-const { dbGetAll, dbGet } = require("@modules/database");
+const { dbGet } = require("@modules/database");
+const { resolveAPIKey } = require("@services/api-key-service");
 const { classStateStore } = require("@services/classroom-service");
 const { createSocket, createSocketUpdates, testData } = require("@modules/tests/tests");
 
@@ -52,9 +54,7 @@ describe("backwards-compat", () => {
 
         it("should emit an error when no user matches the API key", async () => {
             socket.request.session.email = null;
-            const { compareBcrypt } = require("@modules/crypto");
-            dbGetAll.mockResolvedValueOnce([{ id: 1, email: "other@test.com", API: "hashed" }]);
-            compareBcrypt.mockResolvedValue(false);
+            resolveAPIKey.mockResolvedValueOnce(null);
 
             await getActiveClassHandler("invalidKey");
             expect(socket.emit).toHaveBeenCalledWith("error", "Invalid API key.");

--- a/sockets/tests/backwards-compat.spec.js
+++ b/sockets/tests/backwards-compat.spec.js
@@ -52,9 +52,9 @@ describe("backwards-compat", () => {
 
         it("should emit an error when no user matches the API key", async () => {
             socket.request.session.email = null;
-            const { compare } = require("@modules/crypto");
+            const { compareBcrypt } = require("@modules/crypto");
             dbGetAll.mockResolvedValueOnce([{ id: 1, email: "other@test.com", API: "hashed" }]);
-            compare.mockResolvedValue(false);
+            compareBcrypt.mockResolvedValue(false);
 
             await getActiveClassHandler("invalidKey");
             expect(socket.emit).toHaveBeenCalledWith("error", "Invalid API key.");

--- a/sockets/tests/middleware-rate-limiter.spec.js
+++ b/sockets/tests/middleware-rate-limiter.spec.js
@@ -20,15 +20,15 @@ jest.mock("@modules/socket-error-handler", () => ({
     handleSocketError: jest.fn(),
 }));
 
-const rateLimitsByEmail = {};
+const rateLimitsByIdentifier = {};
 
 jest.mock("@stores/socket-state-store", () => ({
     socketStateStore: {
-        getUserRateLimits: jest.fn((email) => {
-            if (!rateLimitsByEmail[email]) {
-                rateLimitsByEmail[email] = {};
+        getUserRateLimits: jest.fn((identifier) => {
+            if (!rateLimitsByIdentifier[identifier]) {
+                rateLimitsByIdentifier[identifier] = {};
             }
-            return rateLimitsByEmail[email];
+            return rateLimitsByIdentifier[identifier];
         }),
     },
 }));
@@ -75,8 +75,8 @@ describe("socket rate-limiter middleware", () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        for (const key of Object.keys(rateLimitsByEmail)) {
-            delete rateLimitsByEmail[key];
+        for (const key of Object.keys(rateLimitsByIdentifier)) {
+            delete rateLimitsByIdentifier[key];
         }
     });
 
@@ -90,5 +90,7 @@ describe("socket rate-limiter middleware", () => {
         expect(getUserDataFromDb).toHaveBeenCalledWith(42);
         expect(next).toHaveBeenCalledTimes(31);
         expect(socket.emit).not.toHaveBeenCalled();
+        expect(rateLimitsByIdentifier).toHaveProperty("42");
+        expect(rateLimitsByIdentifier).not.toHaveProperty("teacher@test.com");
     });
 });

--- a/sockets/tests/poll-removal.spec.js
+++ b/sockets/tests/poll-removal.spec.js
@@ -3,10 +3,15 @@ const { createTestClass, createTestUser, testData, createSocket, createSocketUpd
 const { classStateStore } = require("@services/classroom-service");
 
 jest.mock("@modules/database");
-jest.mock("@modules/logger", () => ({
-    getLogger: jest.fn().mockResolvedValue({ log: jest.fn() }),
-    logEvent: jest.fn(),
-}));
+jest.mock("@modules/logger", () => {
+    const logger = { log: jest.fn() };
+    logger.child = jest.fn(() => logger);
+
+    return {
+        getLogger: jest.fn().mockResolvedValue(logger),
+        logEvent: jest.fn(),
+    };
+});
 
 describe("deletePoll", () => {
     let socket;


### PR DESCRIPTION
This PR solves issue #1048 by allowing null API keys on account creation, using sha256 for API keys, and using a from field to search for pins in the database.

Highlights:
- Null API keys no longer break request handling
    - API keys are now null on user creation to avoid generating an API key that the user can never access
- API keys are now hashed with sha256 since it's more performant, and they're so long that they cannot realistically be guessed
- Digipog transfers now require a from field again to avoid checking against every pin in the database
- Rate limiting now tracks authenticated users by user ID instead of only email/IP