### PR TITLE
Fix sockets containing wrong class ID

### DIFF
--- a/services/socket-updates-service.js
+++ b/services/socket-updates-service.js
@@ -456,19 +456,21 @@ function getClassUpdateData(classData, access, options = { studentEmail: null })
 
     const studentEntries = access.canReadStudents ? Object.entries(classData.students) : viewerStudent ? [[options.studentEmail, viewerStudent]] : [];
 
-        const result = {
-            id: classData.id,
-            className: classData.className,
-            isActive: classData.isActive,
-            owner: classData.owner,
-            timer: access.canReadTimer ? classData.timer : undefined,
+    const result = {
+        id: classData.id,
+        className: classData.className,
+        isActive: classData.isActive,
+        owner: classData.owner,
+        timer: access.canReadTimer ? classData.timer : undefined,
         poll: access.canReadPoll ? poll : undefined,
         key: access.canReadKey ? classData.key : undefined,
         tags: access.canManageTags ? classData.tags : undefined,
         settings: access.canReadSettings ? classData.settings : undefined,
         roles: access.canReadRoles ? classData.availableRoles || [] : undefined,
-            students: studentEntries.length ? Object.fromEntries(studentEntries.map(([email, student]) => [student.id, getClassStudentSnapshot(student, email)])) : undefined,
-        };
+        students: studentEntries.length
+            ? Object.fromEntries(studentEntries.map(([email, student]) => [student.id, getClassStudentSnapshot(student, email)]))
+            : undefined,
+    };
 
     // If studentEmail is provided, include personalized data for that student
     if (viewerStudent) {

--- a/services/user-service.js
+++ b/services/user-service.js
@@ -499,18 +499,15 @@ async function regenerateAPIKey(userId) {
 // User lookup
 
 /**
- * Gets the class id for the given user by checking in-memory classrooms.
+ * Gets the class id for the given user
  * @param {string} email - User email.
  * @returns {number|null|Error}
  */
 function getUserClass(email) {
     try {
-        const allClassrooms = classStateStore.getAllClassrooms();
-        for (const classroomId in allClassrooms) {
-            const classroom = allClassrooms[classroomId];
-            if (classroom.students[email]) {
-                return classroom.id;
-            }
+        const user = classStateStore.getUser(email);
+        if (user?.activeClass) {
+            return user.activeClass;
         }
         return null;
     } catch (err) {

--- a/sockets/middleware/api.js
+++ b/sockets/middleware/api.js
@@ -45,12 +45,14 @@ function ensureStudentExists(userData) {
  * Sets up socket session data for an authenticated user.
  */
 function setupSocketSession(socket, userData, includeApi = false) {
+    const activeClassId = getUserClass(userData.email) ?? null;
     if (includeApi) {
         socket.request.session.api = userData.API;
     }
+
     socket.request.session.userId = userData.id;
     socket.request.session.email = userData.email;
-    socket.request.session.classId = getUserClass(userData.email);
+    socket.request.session.classId = activeClassId;
 }
 
 /**


### PR DESCRIPTION
Previously, the `getUserClass` function would loop through classrooms looking for which class you're in, but this could cause the wrong class to be selected if it was in a smaller array index since you can be in the students array even after leaving due to still being associated with the classroom.

This PR changes it to properly use activeClass.