### PR TITLE
Add additional poll options

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+Formbar.ts-client/

--- a/api/v1/controllers/class/polls/create.js
+++ b/api/v1/controllers/class/polls/create.js
@@ -118,17 +118,17 @@ module.exports = (router) => {
             // Check if the request is legacy and remap them if so
             const pollData = isLegacy
                 ? {
-                    prompt: body.pollPrompt,
-                    answers: Array.isArray(body.polls) ? body.polls : [],
-                    blind: body.blind,
-                    weight: body.weight,
-                    excludedRespondents: Array.isArray(body.boxes) ? body.boxes : undefined,
-                    indeterminate: Array.isArray(body.indeterminate) ? body.indeterminate : [],
-                    allowTextResponses: !!body.responseTextBox,
-                    allowMultipleResponses: !!body.multiRes,
-                    autoEndTimer: body.autoEndTimer,
-                    autoEndThreshold: body.autoEndThreshold,
-                    blindUntilEnded: body.blindUntilEnded != null ? !!body.blindUntilEnded : undefined,
+                      prompt: body.pollPrompt,
+                      answers: Array.isArray(body.polls) ? body.polls : [],
+                      blind: body.blind,
+                      weight: body.weight,
+                      excludedRespondents: Array.isArray(body.boxes) ? body.boxes : undefined,
+                      indeterminate: Array.isArray(body.indeterminate) ? body.indeterminate : [],
+                      allowTextResponses: !!body.responseTextBox,
+                      allowMultipleResponses: !!body.multiRes,
+                      autoEndTimer: body.autoEndTimer,
+                      autoEndThreshold: body.autoEndThreshold,
+                      blindUntilEnded: body.blindUntilEnded != null ? !!body.blindUntilEnded : undefined,
                   }
                 : body;
 

--- a/api/v1/controllers/class/polls/create.js
+++ b/api/v1/controllers/class/polls/create.js
@@ -117,8 +117,9 @@ module.exports = (router) => {
                       indeterminate: Array.isArray(body.indeterminate) ? body.indeterminate : [],
                       allowTextResponses: !!body.responseTextBox,
                       allowMultipleResponses: !!body.multiRes,
-                      autoEndTimer: Number(body.time),
+                      autoEndTimer: body.autoEndTimer,
                       autoEndThreshold: body.autoEndThreshold,
+                      blindUntilEnded: body.blindUntilEnded,
                   }
                 : body;
 

--- a/api/v1/controllers/class/polls/create.js
+++ b/api/v1/controllers/class/polls/create.js
@@ -117,6 +117,8 @@ module.exports = (router) => {
                       indeterminate: Array.isArray(body.indeterminate) ? body.indeterminate : [],
                       allowTextResponses: !!body.responseTextBox,
                       allowMultipleResponses: !!body.multiRes,
+                      autoEndTimer: Number(body.time),
+                      autoEndThreshold: body.autoEndThreshold,
                   }
                 : body;
 

--- a/api/v1/controllers/class/polls/create.js
+++ b/api/v1/controllers/class/polls/create.js
@@ -76,6 +76,15 @@ module.exports = (router) => {
      *               allowMultipleResponses:
      *                 type: boolean
      *                 example: false
+     *               autoEndTimer:
+     *                 type: number
+     *                 example: 10
+     *               autoEndThreshold:
+     *                 type: number
+     *                 example: 50
+     *               blindUntilEnded:
+     *                 type: boolean
+     *                 example: false
      *     responses:
      *       200:
      *         description: Poll created successfully
@@ -109,17 +118,17 @@ module.exports = (router) => {
             // Check if the request is legacy and remap them if so
             const pollData = isLegacy
                 ? {
-                      prompt: body.pollPrompt,
-                      answers: Array.isArray(body.polls) ? body.polls : [],
-                      blind: body.blind,
-                      weight: body.weight,
-                      excludedRespondents: Array.isArray(body.boxes) ? body.boxes : undefined,
-                      indeterminate: Array.isArray(body.indeterminate) ? body.indeterminate : [],
-                      allowTextResponses: !!body.responseTextBox,
-                      allowMultipleResponses: !!body.multiRes,
-                      autoEndTimer: body.autoEndTimer,
-                      autoEndThreshold: body.autoEndThreshold,
-                      blindUntilEnded: body.blindUntilEnded,
+                    prompt: body.pollPrompt,
+                    answers: Array.isArray(body.polls) ? body.polls : [],
+                    blind: body.blind,
+                    weight: body.weight,
+                    excludedRespondents: Array.isArray(body.boxes) ? body.boxes : undefined,
+                    indeterminate: Array.isArray(body.indeterminate) ? body.indeterminate : [],
+                    allowTextResponses: !!body.responseTextBox,
+                    allowMultipleResponses: !!body.multiRes,
+                    autoEndTimer: body.autoEndTimer,
+                    autoEndThreshold: body.autoEndThreshold,
+                    blindUntilEnded: body.blindUntilEnded != null ? !!body.blindUntilEnded : undefined,
                   }
                 : body;
 

--- a/api/v1/controllers/tests/class-polls.spec.js
+++ b/api/v1/controllers/tests/class-polls.spec.js
@@ -179,6 +179,37 @@ describe("POST /api/v1/class/:id/polls/create", () => {
             expect.objectContaining({ email: "teacher@test.com" })
         );
     });
+
+    it("maps legacy auto-end options when creating a poll", async () => {
+        const { classId, teacherTokens } = await setupClassWithTeacher();
+        const { createPoll } = require("@services/poll-service");
+
+        const res = await request(app)
+            .post(`/api/v1/class/${classId}/polls/create`)
+            .set("Authorization", `Bearer ${teacherTokens.accessToken}`)
+            .send({
+                pollPrompt: "Timed?",
+                polls: [{ answer: "Yes" }],
+                blind: true,
+                responseTextBox: false,
+                multiRes: false,
+                autoEndTimer: 5000,
+                autoEndThreshold: 80,
+                blindUntilEnded: true,
+            });
+
+        expect(res.status).toBe(200);
+        expect(createPoll).toHaveBeenCalledWith(
+            String(classId),
+            expect.objectContaining({
+                prompt: "Timed?",
+                autoEndTimer: 5000,
+                autoEndThreshold: 80,
+                blindUntilEnded: true,
+            }),
+            expect.objectContaining({ email: "teacher@test.com" })
+        );
+    });
 });
 
 describe("POST /api/v1/class/:id/polls/end", () => {

--- a/database/migrations/38_add_poll_options_to_poll_history.sql
+++ b/database/migrations/38_add_poll_options_to_poll_history.sql
@@ -1,6 +1,6 @@
 -- 38_add_poll_options_to_poll_history.sql
--- This migration adds the time, auto_end_threshold, and auto_end_timer columns to the poll_history table.
+-- This migration adds auto-end poll option columns to the poll_history table.
 
-ALTER TABLE poll_history ADD COLUMN IF NOT EXISTS "auto_end_timer" INTEGER;
-ALTER TABLE poll_history ADD COLUMN IF NOT EXISTS "auto_end_threshold" INTEGER;
-ALTER TABLE poll_history ADD COLUMN IF NOT EXISTS "blind_until_ended" INTEGER NOT NULL DEFAULT 0 CHECK ("blind_until_ended" IN (0, 1));
+ALTER TABLE poll_history ADD COLUMN "auto_end_timer" INTEGER;
+ALTER TABLE poll_history ADD COLUMN "auto_end_threshold" INTEGER;
+ALTER TABLE poll_history ADD COLUMN "blind_until_ended" INTEGER NOT NULL DEFAULT 0 CHECK ("blind_until_ended" IN (0, 1));

--- a/database/migrations/38_add_poll_options_to_poll_history.sql
+++ b/database/migrations/38_add_poll_options_to_poll_history.sql
@@ -1,5 +1,6 @@
 -- 38_add_poll_options_to_poll_history.sql
 -- This migration adds the time, auto_end_threshold, and auto_end_timer columns to the poll_history table.
 
-ALTER TABLE poll_history ADD COLUMN "auto_end_timer" INTEGER;
-ALTER TABLE poll_history ADD COLUMN "auto_end_threshold" INTEGER;
+ALTER TABLE poll_history ADD COLUMN IF NOT EXISTS "auto_end_timer" INTEGER;
+ALTER TABLE poll_history ADD COLUMN IF NOT EXISTS "auto_end_threshold" INTEGER;
+ALTER TABLE poll_history ADD COLUMN IF NOT EXISTS "blind_until_ended" INTEGER NOT NULL DEFAULT 0 CHECK ("blind_until_ended" IN (0, 1));

--- a/database/migrations/38_add_poll_options_to_poll_history.sql
+++ b/database/migrations/38_add_poll_options_to_poll_history.sql
@@ -1,0 +1,5 @@
+-- 38_add_poll_options_to_poll_history.sql
+-- This migration adds the time, auto_end_threshold, and auto_end_timer columns to the poll_history table.
+
+ALTER TABLE poll_history ADD COLUMN "auto_end_timer" INTEGER;
+ALTER TABLE poll_history ADD COLUMN "auto_end_threshold" INTEGER;

--- a/database/migrations/JSMigrations/14_restructure_transactions.js
+++ b/database/migrations/JSMigrations/14_restructure_transactions.js
@@ -6,14 +6,17 @@ module.exports = {
     async run(database) {
         const columns = await dbGetAll("PRAGMA table_info(transactions)", [], database);
         const fromUserColumn = columns.find((column) => column.name === "from_user");
-        if (fromUserColumn) {
-            // If the column exists, then this is a legacy transactions table
-            // Transfer the data to a new table with the new layout
-            const transactions = await dbGetAll("SELECT * FROM transactions", [], database);
+        if (!fromUserColumn) {
+            throw new Error("ALREADY_DONE");
+        }
 
+        // If the column exists, then this is a legacy transactions table.
+        await dbRun("BEGIN TRANSACTION", [], database);
+        try {
             // Create new temporary table
+            await dbRun("DROP TABLE IF EXISTS transactions_temp", [], database);
             await dbRun(
-                `CREATE TABLE IF NOT EXISTS transactions_temp (
+                `CREATE TABLE transactions_temp (
                     "from_id"   INTEGER NOT NULL,
                     "to_id"     INTEGER NOT NULL,
                     "from_type" TEXT NOT NULL,
@@ -26,56 +29,64 @@ module.exports = {
                 database
             );
 
-            // Migrate data
-            for (const transaction of transactions) {
-                let fromId, fromType, toId, toType;
-
-                if (!transaction.from_user && transaction.pool) {
-                    // Pool to user transaction
-                    fromId = transaction.pool;
-                    fromType = "pool";
-                    toId = transaction.to_user;
-                    toType = "user";
-                } else if (!transaction.to_user && transaction.pool) {
-                    // User to pool transaction
-                    toId = transaction.pool;
-                    toType = "pool";
-                    fromId = transaction.from_user;
-                    fromType = "user";
-                } else if (transaction.from_user && transaction.to_user) {
-                    // User to user transaction
-                    fromId = transaction.from_user;
-                    fromType = "user";
-                    toId = transaction.to_user;
-                    toType = "user";
-                } else if (!transaction.from_user && transaction.to_user) {
-                    // Pool to user transaction
-                    fromId = 0;
-                    fromType = "pool";
-                    toId = transaction.to_user;
-                    toType = "user";
-                } else if (transaction.from_user && !transaction.to_user) {
-                    // User to pool transaction
-                    fromId = transaction.from_user;
-                    fromType = "user";
-                    toId = 0;
-                    toType = "pool";
-                } else {
-                    throw new Error("Invalid transaction data");
-                }
-
-                await dbRun(
-                    "INSERT INTO transactions_temp (from_id, to_id, from_type, to_type, amount, reason, date) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    [fromId, toId, fromType, toType, transaction.amount, transaction.reason, transaction.date],
-                    database
-                );
-            }
+            // Migrate data in one SQLite statement instead of round-tripping once per row.
+            await dbRun(
+                `INSERT INTO transactions_temp (from_id, to_id, from_type, to_type, amount, reason, date)
+                WITH normalized_transactions AS (
+                    SELECT
+                        *,
+                        (from_user IS NULL OR from_user = 0) AS missing_from_user,
+                        (to_user IS NULL OR to_user = 0) AS missing_to_user,
+                        (from_user IS NOT NULL AND from_user != 0) AS has_from_user,
+                        (to_user IS NOT NULL AND to_user != 0) AS has_to_user,
+                        (pool IS NOT NULL AND pool != 0) AS has_pool
+                    FROM transactions
+                )
+                SELECT
+                    CASE
+                        WHEN missing_from_user AND has_pool THEN pool
+                        WHEN missing_to_user AND has_pool THEN from_user
+                        WHEN has_from_user AND has_to_user THEN from_user
+                        WHEN missing_from_user AND has_to_user THEN 0
+                        WHEN has_from_user AND missing_to_user THEN from_user
+                    END AS from_id,
+                    CASE
+                        WHEN missing_from_user AND has_pool THEN to_user
+                        WHEN missing_to_user AND has_pool THEN pool
+                        WHEN has_from_user AND has_to_user THEN to_user
+                        WHEN missing_from_user AND has_to_user THEN to_user
+                        WHEN has_from_user AND missing_to_user THEN 0
+                    END AS to_id,
+                    CASE
+                        WHEN missing_from_user AND has_pool THEN 'pool'
+                        WHEN missing_to_user AND has_pool THEN 'user'
+                        WHEN has_from_user AND has_to_user THEN 'user'
+                        WHEN missing_from_user AND has_to_user THEN 'pool'
+                        WHEN has_from_user AND missing_to_user THEN 'user'
+                    END AS from_type,
+                    CASE
+                        WHEN missing_from_user AND has_pool THEN 'user'
+                        WHEN missing_to_user AND has_pool THEN 'pool'
+                        WHEN has_from_user AND has_to_user THEN 'user'
+                        WHEN missing_from_user AND has_to_user THEN 'user'
+                        WHEN has_from_user AND missing_to_user THEN 'pool'
+                    END AS to_type,
+                    amount,
+                    reason,
+                    date
+                FROM normalized_transactions;`,
+                [],
+                database
+            );
 
             // Drop the old transactions table and rename the new one
             await dbRun("DROP TABLE IF EXISTS transactions", [], database);
             await dbRun("ALTER TABLE transactions_temp RENAME TO transactions", [], database);
-        } else {
-            throw new Error("ALREADY_DONE");
+
+            await dbRun("COMMIT", [], database);
+        } catch (err) {
+            await dbRun("ROLLBACK", [], database);
+            throw err;
         }
     },
 };

--- a/services/classroom-service.js
+++ b/services/classroom-service.js
@@ -34,6 +34,7 @@ class Classroom {
             allowTextResponses: false,
             allowMultipleResponses: false,
             blind: false,
+            blindUntilEnded: false,
             weight: 1,
             excludedRespondents: [],
         };

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -159,7 +159,7 @@ function updateStudentPollResponse(student, res, textRes, isRemoving, allowMulti
  * @throws {ValidationError} If class is not active
  */
 async function createPoll(classId, pollData, userData) {
-    const { prompt, answers, blind, weight, excludedRespondents, allowVoteChanges, allowTextResponses, allowMultipleResponses } = pollData;
+    const { prompt, answers, blind, weight, excludedRespondents, allowVoteChanges, allowTextResponses, allowMultipleResponses, autoEndTimer, autoEndThreshold } = pollData;
     const numberOfResponses = Object.keys(answers).length;
 
     requireInternalParam(classId, "classId");
@@ -221,11 +221,19 @@ async function createPoll(classId, pollData, userData) {
 
     // Set the poll's data in the classroom
     pollRuntimeStore.setPollStartTime(classId, pollStartTime);
-    classroom.poll.startTime = pollStartTime;
-    classroom.poll.weight = weight;
-    classroom.poll.allowTextResponses = allowTextResponses;
-    classroom.poll.prompt = prompt;
-    classroom.poll.allowMultipleResponses = allowMultipleResponses;
+    classroom.poll = {
+        ...classroom.poll,
+        startTime: pollStartTime,
+        weight: weight,
+        allowTextResponses: allowTextResponses,
+        prompt: prompt,
+        allowMultipleResponses: allowMultipleResponses,
+        time: time,
+        autoEndThreshold: autoEndThreshold,
+        autoEndTimer: autoEndTimer,
+    };
+
+    watchPoll(classId, classroom.poll);
 
     resetStudentPollResponses(classroom);
     userUpdateSocket(userData.email, "classUpdate", classId, { global: true });
@@ -359,10 +367,12 @@ async function savePollToHistory(classId) {
     const allowMultipleResponses = classroom.poll.allowMultipleResponses ? 1 : 0;
     const blind = classroom.poll.blind ? 1 : 0;
     const allowTextResponses = classroom.poll.allowTextResponses ? 1 : 0;
+    const autoEndTimer = classroom.poll.autoEndTimer;
+    const autoEndThreshold = classroom.poll.autoEndThreshold;
 
     return dbRun(
-        "INSERT INTO poll_history(class, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?)",
-        [classId, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt]
+        "INSERT INTO poll_history(class, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt, auto_end_timer, auto_end_threshold) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [classId, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt, autoEndTimer, autoEndThreshold]
     );
 }
 
@@ -623,6 +633,50 @@ async function deleteCustomPolls(userId) {
     }
 }
 
+// Map of classId to timeout id
+// Used to clear the timeout when the poll is cleared
+const watchedPolls = new Map();
+
+/**
+ * Watches the poll for certain conditions which will trigger an automatic end of the poll.
+ * @param {number} classId - The ID of the class.
+ * @returns {Promise<void>}
+ */
+function watchPoll(classId, pollData) {
+    const { autoEndTimer, autoEndThreshold } = pollData;
+    if (autoEndTimer) {
+        watchedPolls.set(classId, setTimeout(() => {
+            const classroom = classStateStore.getClassroom(classId);
+            if (!classroom || !classroom.poll || !classroom.poll.status || classroom.poll.startTime !== pollData.startTime) {
+                watchedPolls.delete(classId);
+                return;
+            }
+
+            const pollTime = Date.now() - classroom.poll.startTime;
+            if (pollTime >= autoEndTimer) {
+                if (!autoEndThreshold) {
+                    clearPoll(classId, null, false);
+                    return;
+                }
+
+                const onlineStudents = Object.keys(classroom.students).filter((student) => !classroom.students[student].isOffline).length;
+                const responsePercentage = classroom.poll.responses.length / onlineStudents;
+                if (responsePercentage >= autoEndThreshold) {
+                    clearPoll(classId, null, false);
+                }
+            }
+        }, autoEndTimer);
+    }
+}
+
+function deleteWatchedPoll(classId) {
+    const timer = watchedPolls.get(classId);
+    if (!timer) return;
+
+    clearTimeout(watchedPolls.get(classId));
+    watchedPolls.delete(classId);
+}
+
 module.exports = {
     createPoll,
     updatePoll,
@@ -634,4 +688,5 @@ module.exports = {
     getPollResponses,
     deleteCustomPolls,
     pollRuntimeStore,
+    deleteWatchedPoll,
 };

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -159,7 +159,18 @@ function updateStudentPollResponse(student, res, textRes, isRemoving, allowMulti
  * @throws {ValidationError} If class is not active
  */
 async function createPoll(classId, pollData, userData) {
-    const { prompt, answers, blind, weight, excludedRespondents, allowVoteChanges, allowTextResponses, allowMultipleResponses, autoEndTimer, autoEndThreshold } = pollData;
+    const {
+        prompt,
+        answers,
+        blind,
+        weight,
+        excludedRespondents,
+        allowVoteChanges,
+        allowTextResponses,
+        allowMultipleResponses,
+        autoEndTimer,
+        autoEndThreshold,
+    } = pollData;
     const numberOfResponses = Object.keys(answers).length;
 
     requireInternalParam(classId, "classId");
@@ -645,27 +656,32 @@ const watchedPolls = new Map();
 function watchPoll(classId, pollData) {
     const { autoEndTimer, autoEndThreshold } = pollData;
     if (autoEndTimer) {
-        watchedPolls.set(classId, setTimeout(() => {
-            const classroom = classStateStore.getClassroom(classId);
-            if (!classroom || !classroom.poll || !classroom.poll.status || classroom.poll.startTime !== pollData.startTime) {
-                watchedPolls.delete(classId);
-                return;
-            }
+        watchedPolls
+            .set(
+                classId,
+                setTimeout(() => {
+                    const classroom = classStateStore.getClassroom(classId);
+                    if (!classroom || !classroom.poll || !classroom.poll.status || classroom.poll.startTime !== pollData.startTime) {
+                        watchedPolls.delete(classId);
+                        return;
+                    }
 
-            const pollTime = Date.now() - classroom.poll.startTime;
-            if (pollTime >= autoEndTimer) {
-                if (!autoEndThreshold) {
-                    clearPoll(classId, null, false);
-                    return;
-                }
+                    const pollTime = Date.now() - classroom.poll.startTime;
+                    if (pollTime >= autoEndTimer) {
+                        if (!autoEndThreshold) {
+                            clearPoll(classId, null, false);
+                            return;
+                        }
 
-                const onlineStudents = Object.keys(classroom.students).filter((student) => !classroom.students[student].isOffline).length;
-                const responsePercentage = classroom.poll.responses.length / onlineStudents;
-                if (responsePercentage >= autoEndThreshold) {
-                    clearPoll(classId, null, false);
-                }
-            }
-        }, autoEndTimer);
+                        const onlineStudents = Object.keys(classroom.students).filter((student) => !classroom.students[student].isOffline).length;
+                        const responsePercentage = classroom.poll.responses.length / onlineStudents;
+                        if (responsePercentage >= autoEndThreshold) {
+                            clearPoll(classId, null, false);
+                        }
+                    }
+                }, autoEndTimer)
+            )
+            .unref();
     }
 }
 

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -361,7 +361,7 @@ async function updatePoll(classId, options, userSession) {
     // If an empty object is sent, clear the current poll
     const optionsKeys = Object.keys(options);
     if (optionsKeys.length === 0) {
-        await clearPoll(classId, userSession);
+        await clearPoll(classId, userSession, false);
         return true;
     }
 
@@ -479,6 +479,49 @@ async function savePollToHistory(classId) {
 }
 
 /**
+ * Persists student responses into poll_answers when clearing/archiving the active poll.
+ * @param {Object} classroom - The classroom object (students and scoped admins unchanged).
+ * @param {number} currentPollId - The runtime-tracked poll id for inserted answers.
+ * @param {number} classId - The ID of the class.
+ * @param {Array<Object>} savedPollResponses - Response definitions captured before the poll metadata was cleared.
+ * @returns {Promise<void>}
+ */
+async function savePollAnswersToHistory(classroom, currentPollId, classId, savedPollResponses) {
+    const rows = [];
+    for (const student of Object.values(classroom.students)) {
+        if (!userHasScope(student, SCOPES.CLASS.SYSTEM.ADMIN, classroom)) {
+            const buttonRes = student.pollRes.buttonRes;
+            let buttonResponse = null;
+            if (Array.isArray(buttonRes) && buttonRes.length > 0) {
+                // Multi-response: store the full array
+                buttonResponse = JSON.stringify(buttonRes);
+            } else if (!Array.isArray(buttonRes) && buttonRes !== "" && buttonRes !== null && buttonRes !== undefined) {
+                // Single response: wrap in an array
+                buttonResponse = JSON.stringify([buttonRes]);
+            }
+
+            const textResponse = student.pollRes.textRes || null;
+            const responseIds = getSelectedResponseIds(savedPollResponses, buttonRes);
+
+            if (buttonResponse === null && textResponse === null) continue;
+
+            const studentId = student.id;
+            rows.push([currentPollId, classId, studentId, responseIds, buttonResponse, textResponse, Date.now()]);
+        }
+    }
+
+    if (rows.length > 0) {
+        const placeholders = rows.map(() => "(?, ?, ?, ?, ?, ?, ?)").join(",");
+        const values = rows.flat();
+
+        await dbRun(
+            `INSERT OR REPLACE INTO poll_answers(pollId, classId, userId, responseIds, buttonResponse, textResponse, createdAt) VALUES ${placeholders}`,
+            values
+        );
+    }
+}
+
+/**
  * Clears the current poll in the specified class, optionally updates the class state,
  * and saves poll answers to the database.
  *
@@ -490,9 +533,6 @@ async function savePollToHistory(classId) {
 async function clearPoll(classId, userSession, updateClass = true) {
     const classroom = classStateStore.getClassroom(classId);
     deleteWatchedPoll(classId);
-    if (classroom.poll.status) {
-        await updatePoll(classId, { status: false }, userSession);
-    }
 
     const currentPollId = pollRuntimeStore.getLastSavedPollId(classId);
     const savedPollResponses = classroom.poll.responses;
@@ -513,7 +553,7 @@ async function clearPoll(classId, userSession, updateClass = true) {
         excludedRespondents: [],
     };
 
-    // Adds data to the previous poll answers table upon clearing the poll
+    // If there is no current poll ID, clear the poll and return
     if (!currentPollId) {
         if (updateClass && userSession) {
             emitClassUpdate(classId, userSession);
@@ -524,40 +564,10 @@ async function clearPoll(classId, userSession, updateClass = true) {
         return;
     }
 
-    const rows = [];
-    for (const student of Object.values(classroom.students)) {
-        if (!userHasScope(student, SCOPES.CLASS.SYSTEM.ADMIN, classroom)) {
-            const buttonRes = student.pollRes.buttonRes;
-            let buttonResponse = null;
-            if (Array.isArray(buttonRes) && buttonRes.length > 0) {
-                // Multi-response: store the full array
-                buttonResponse = JSON.stringify(buttonRes);
-            } else if (!Array.isArray(buttonRes) && buttonRes !== "" && buttonRes !== null && buttonRes !== undefined) {
-                // Single response: wrap in an array
-                buttonResponse = JSON.stringify([buttonRes]);
-            }
-
-            const textResponse = student.pollRes.textRes || null;
-            const responseIds = getSelectedResponseIds(savedPollResponses, buttonRes);
-
-            // Skip students with no response at all
-            if (buttonResponse === null && textResponse === null) continue;
-
-            const studentId = student.id;
-            rows.push([currentPollId, classId, studentId, responseIds, buttonResponse, textResponse, Date.now()]);
-        }
-    }
-
-    // Insert all of the poll answers into the database at once
-    if (rows.length > 0) {
-        const placeholders = rows.map(() => "(?, ?, ?, ?, ?, ?, ?)").join(",");
-        const values = rows.flat();
-
-        await dbRun(
-            `INSERT OR REPLACE INTO poll_answers(pollId, classId, userId, responseIds, buttonResponse, textResponse, createdAt) VALUES ${placeholders}`,
-            values
-        );
-    }
+    // Save poll to history
+    await savePollAnswersToHistory(classroom, currentPollId, classId, savedPollResponses);
+    await savePollToHistory(classId);
+    pollRuntimeStore.setLastSavedPollId(classId, currentPollId);
 
     if (updateClass && userSession) {
         emitClassUpdate(classId, userSession);

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -748,7 +748,7 @@ const watchedPolls = new Map();
 /**
  * Watches the poll for certain conditions which will trigger an automatic end of the poll.
  * @param {number} classId - The ID of the class.
- * @returns {Promise<void>}
+ * @returns {boolean} True if the poll is being watched, false otherwise.
  */
 function watchPoll(classId, pollData) {
     const classroom = classStateStore.getClassroom(classId);

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -47,8 +47,8 @@ function resetStudentPollResponses(classroom) {
  */
 function isUserExcludedFromVoting(classroom, user, student) {
     // Check if user is excluded from voting using poll.excludedRespondents
-    if (classroom.poll.excludedRespondents && classroom.poll.excludedRespondents.includes(user.id)) {
-        logger.log("info", `[pollResponse] User ${user.id} is excluded from voting`);
+    const userId = user?.id ?? student?.id;
+    if (userId !== undefined && classroom.poll.excludedRespondents && classroom.poll.excludedRespondents.includes(userId)) {
         return true;
     }
 
@@ -128,6 +128,87 @@ function getSelectedResponseIds(pollResponses, buttonRes) {
     return responseIds.length > 0 ? JSON.stringify(responseIds) : null;
 }
 
+function normalizePositiveNumber(value) {
+    if (value === null || value === undefined || value === "") return null;
+    return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function normalizeThresholdPercent(value) {
+    const threshold = normalizePositiveNumber(value);
+    if (threshold === null) return null;
+    return Math.min(threshold > 1 ? threshold / 100 : threshold, 1);
+}
+
+function hasStudentAnsweredPoll(student) {
+    if (!student || !student.pollRes) return false;
+
+    const buttonRes = student.pollRes.buttonRes;
+    if (Array.isArray(buttonRes)) {
+        return buttonRes.length > 0;
+    }
+
+    if (buttonRes !== "" && buttonRes !== null && buttonRes !== undefined) {
+        return true;
+    }
+
+    const textRes = student.pollRes.textRes;
+    return textRes !== "" && textRes !== null && textRes !== undefined;
+}
+
+function getEligiblePollStudents(classroom) {
+    if (!classroom || !classroom.students) return [];
+
+    const excludedRespondents = Array.isArray(classroom.poll?.excludedRespondents) ? classroom.poll.excludedRespondents.map(Number) : [];
+
+    return Object.values(classroom.students).filter((student) => {
+        if (!student || student.isOffline || student.break === true) return false;
+        if (excludedRespondents.includes(Number(student.id))) return false;
+        if (userHasScope(student, SCOPES.CLASS.SYSTEM.ADMIN, classroom)) return false;
+        return true;
+    });
+}
+
+function getAutoEndDelay(classroom, autoEndTimer) {
+    const configuredDelay = normalizePositiveNumber(autoEndTimer);
+    if (configuredDelay === null) return null;
+
+    const classTimer = classroom?.timer;
+    if (!classTimer || !classTimer.active || !Number.isFinite(Number(classTimer.endTime))) {
+        return configuredDelay;
+    }
+
+    const remainingClassTime = Number(classTimer.endTime) - Date.now();
+    if (remainingClassTime <= 0) return null;
+
+    return Math.min(configuredDelay, remainingClassTime);
+}
+
+function isAutoEndThresholdMet(classroom) {
+    const threshold = normalizeThresholdPercent(classroom.poll?.autoEndThreshold);
+    if (threshold === null) return true;
+
+    const eligibleStudents = getEligiblePollStudents(classroom);
+    if (eligibleStudents.length === 0) return false;
+
+    const answeredStudents = eligibleStudents.filter(hasStudentAnsweredPoll).length;
+    return answeredStudents / eligibleStudents.length >= threshold;
+}
+
+function emitClassUpdate(classId, userSession) {
+    if (userSession?.email && userUpdateSocket(userSession.email, "classUpdate", classId, { global: true })) {
+        return;
+    }
+
+    for (const socketUpdatesSet of userSocketUpdates.values()) {
+        for (const socketUpdates of socketUpdatesSet.values()) {
+            if (socketUpdates && typeof socketUpdates.classUpdate === "function") {
+                socketUpdates.classUpdate(classId, { global: true });
+                return;
+            }
+        }
+    }
+}
+
 /**
  * Updates a student's poll response state.
  * @param {Object} student - The student object.
@@ -173,6 +254,9 @@ async function createPoll(classId, pollData, userData) {
         blindUntilEnded,
     } = pollData;
     const numberOfResponses = Object.keys(answers).length;
+    const normalizedAutoEndTimer = normalizePositiveNumber(autoEndTimer);
+    const normalizedAutoEndThreshold = normalizePositiveNumber(autoEndThreshold);
+    const shouldBlindUntilEnded = blind ? blindUntilEnded !== false : !!blindUntilEnded;
 
     requireInternalParam(classId, "classId");
     requireInternalParam(pollData, "pollData");
@@ -192,6 +276,7 @@ async function createPoll(classId, pollData, userData) {
 
     classroom.poll.allowVoteChanges = allowVoteChanges;
     classroom.poll.blind = blind;
+    classroom.poll.blindUntilEnded = shouldBlindUntilEnded;
     classroom.poll.status = true;
 
     // If excludedRespondents is provided and is a non-empty array, use it directly
@@ -240,15 +325,15 @@ async function createPoll(classId, pollData, userData) {
         allowTextResponses: allowTextResponses,
         prompt: prompt,
         allowMultipleResponses: allowMultipleResponses,
-        time: time,
-        autoEndThreshold: autoEndThreshold,
-        autoEndTimer: autoEndTimer,
+        endTime: null,
+        autoEndTimer: normalizedAutoEndTimer,
+        autoEndThreshold: normalizedAutoEndThreshold,
+        blindUntilEnded: shouldBlindUntilEnded,
     };
 
-    watchPoll(classId, classroom.poll);
-
     resetStudentPollResponses(classroom);
-    userUpdateSocket(userData.email, "classUpdate", classId, { global: true });
+    watchPoll(classId, classroom.poll);
+    emitClassUpdate(classId, userData);
 }
 
 /**
@@ -286,11 +371,14 @@ async function updatePoll(classId, options, userSession) {
 
         // Save to history when ending poll
         if (option === "status" && value === false && classroom.poll.status === true) {
+            deleteWatchedPoll(classId);
+
             // If the poll is set to blind until ended, then unblind the poll
             if (classroom.poll.blindUntilEnded) {
                 classroom.poll.blind = false;
             }
 
+            classroom.poll.status = false;
             const savedPollId = await savePollToHistory(classId);
             pollRuntimeStore.setLastSavedPollId(classId, savedPollId);
         }
@@ -307,11 +395,7 @@ async function updatePoll(classId, options, userSession) {
     }
 
     // Broadcast update to all tabs
-    const userSockets = userSocketUpdates.get(userSession.email);
-    if (userSockets && userSockets.size > 0) {
-        const firstSocket = userSockets.values().next().value;
-        firstSocket.classUpdate(classId, { global: true });
-    }
+    emitClassUpdate(classId, userSession);
     return true;
 }
 
@@ -386,10 +470,11 @@ async function savePollToHistory(classId) {
     const allowTextResponses = classroom.poll.allowTextResponses ? 1 : 0;
     const autoEndTimer = classroom.poll.autoEndTimer;
     const autoEndThreshold = classroom.poll.autoEndThreshold;
+    const blindUntilEnded = classroom.poll.blindUntilEnded ? 1 : 0;
 
     return dbRun(
-        "INSERT INTO poll_history(class, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt, auto_end_timer, auto_end_threshold) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [classId, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt, autoEndTimer, autoEndThreshold]
+        "INSERT INTO poll_history(class, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt, auto_end_timer, auto_end_threshold, blind_until_ended) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [classId, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt, autoEndTimer, autoEndThreshold, blindUntilEnded]
     );
 }
 
@@ -404,6 +489,7 @@ async function savePollToHistory(classId) {
  */
 async function clearPoll(classId, userSession, updateClass = true) {
     const classroom = classStateStore.getClassroom(classId);
+    deleteWatchedPoll(classId);
     if (classroom.poll.status) {
         await updatePoll(classId, { status: false }, userSession);
     }
@@ -420,13 +506,17 @@ async function clearPoll(classId, userSession, updateClass = true) {
         prompt: "",
         weight: 1,
         blind: false,
+        blindUntilEnded: false,
+        endTime: null,
+        autoEndTimer: null,
+        autoEndThreshold: null,
         excludedRespondents: [],
     };
 
     // Adds data to the previous poll answers table upon clearing the poll
     if (!currentPollId) {
         if (updateClass && userSession) {
-            userUpdateSocket(userSession.email, "classUpdate", classId, { global: true });
+            emitClassUpdate(classId, userSession);
         }
         pollRuntimeStore.clearPogMeterTracker(classId);
         pollRuntimeStore.clearLastSavedPollId(classId);
@@ -470,7 +560,7 @@ async function clearPoll(classId, userSession, updateClass = true) {
     }
 
     if (updateClass && userSession) {
-        userUpdateSocket(userSession.email, "classUpdate", classId, { global: true });
+        emitClassUpdate(classId, userSession);
     }
 
     pollRuntimeStore.clearPogMeterTracker(classId);
@@ -560,7 +650,8 @@ async function sendPollResponse(classId, res, textRes, userSession) {
         pollRuntimeStore.markPogMeterIncreased(classId, email);
     }
 
-    userUpdateSocket(email, "classUpdate", classId, { global: true });
+    watchPoll(classId, classroom.poll);
+    emitClassUpdate(classId, userSession);
 }
 
 /**
@@ -660,35 +751,35 @@ const watchedPolls = new Map();
  * @returns {Promise<void>}
  */
 function watchPoll(classId, pollData) {
-    const { autoEndTimer, autoEndThreshold } = pollData;
-    if (autoEndTimer) {
-        watchedPolls
-            .set(
-                classId,
-                setTimeout(() => {
-                    const classroom = classStateStore.getClassroom(classId);
-                    if (!classroom || !classroom.poll || !classroom.poll.status || classroom.poll.startTime !== pollData.startTime) {
-                        watchedPolls.delete(classId);
-                        return;
-                    }
+    const classroom = classStateStore.getClassroom(classId);
+    if (!classroom || !classroom.poll || !classroom.poll.status || watchedPolls.has(classId)) return false;
 
-                    const pollTime = Date.now() - classroom.poll.startTime;
-                    if (pollTime >= autoEndTimer) {
-                        if (!autoEndThreshold) {
-                            clearPoll(classId, null, false);
-                            return;
-                        }
+    const autoEndTimer = normalizePositiveNumber(pollData.autoEndTimer);
+    if (autoEndTimer === null || !isAutoEndThresholdMet(classroom)) return false;
 
-                        const onlineStudents = Object.keys(classroom.students).filter((student) => !classroom.students[student].isOffline).length;
-                        const responsePercentage = classroom.poll.responses.length / onlineStudents;
-                        if (responsePercentage >= autoEndThreshold) {
-                            clearPoll(classId, null, false);
-                        }
-                    }
-                }, autoEndTimer)
-            )
-            .unref();
+    const autoEndDelay = getAutoEndDelay(classroom, autoEndTimer);
+    if (autoEndDelay === null) return false;
+
+    const pollStartTime = classroom.poll.startTime;
+    classroom.poll.endTime = Date.now() + autoEndDelay;
+
+    const timer = setTimeout(async () => {
+        const activeClassroom = classStateStore.getClassroom(classId);
+        watchedPolls.delete(classId);
+
+        if (!activeClassroom || !activeClassroom.poll || !activeClassroom.poll.status || activeClassroom.poll.startTime !== pollStartTime) {
+            return;
+        }
+
+        await updatePoll(classId, { status: false }, null);
+    }, autoEndDelay);
+
+    if (typeof timer.unref === "function") {
+        timer.unref();
     }
+
+    watchedPolls.set(classId, timer);
+    return true;
 }
 
 function deleteWatchedPoll(classId) {

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -1,7 +1,7 @@
 const { classStateStore } = require("@services/classroom-service");
 
 const { generateColors } = require("@modules/util");
-const { advancedEmitToClass, userUpdateSocket } = require("@services/socket-updates-service");
+const { advancedEmitToClass } = require("@services/socket-updates-service");
 const { dbGet, dbGetAll, dbRun } = require("@modules/database");
 const { userHasScope } = require("@modules/scope-resolver");
 const { SCOPES } = require("@modules/permissions");
@@ -195,8 +195,15 @@ function isAutoEndThresholdMet(classroom) {
 }
 
 function emitClassUpdate(classId, userSession) {
-    if (userSession?.email && userUpdateSocket(userSession.email, "classUpdate", classId, { global: true })) {
-        return;
+    if (userSession?.email) {
+        const userSockets = userSocketUpdates.get(userSession.email);
+        if (userSockets && userSockets.size > 0) {
+            const firstSocketUpdates = userSockets.values().next().value;
+            if (firstSocketUpdates && typeof firstSocketUpdates.classUpdate === "function") {
+                firstSocketUpdates.classUpdate(classId, { global: true });
+                return;
+            }
+        }
     }
 
     for (const socketUpdatesSet of userSocketUpdates.values()) {
@@ -458,19 +465,21 @@ async function getPreviousPolls(classId, limit = 20, offset = 0) {
  * @param {number} classId - The ID of the class whose poll should be saved.
  * @returns {Promise<void>}
  */
-async function savePollToHistory(classId) {
+async function savePollToHistory(classId, pollSnapshot = null) {
     const classroom = classStateStore.getClassroom(classId);
-    if (!classroom) return;
+    if (!classroom && !pollSnapshot) return;
+
+    const pollToSave = pollSnapshot || classroom.poll;
 
     const createdAt = Date.now();
-    const prompt = classroom.poll.prompt;
-    const responses = JSON.stringify(classroom.poll.responses);
-    const allowMultipleResponses = classroom.poll.allowMultipleResponses ? 1 : 0;
-    const blind = classroom.poll.blind ? 1 : 0;
-    const allowTextResponses = classroom.poll.allowTextResponses ? 1 : 0;
-    const autoEndTimer = classroom.poll.autoEndTimer;
-    const autoEndThreshold = classroom.poll.autoEndThreshold;
-    const blindUntilEnded = classroom.poll.blindUntilEnded ? 1 : 0;
+    const prompt = pollToSave.prompt;
+    const responses = JSON.stringify(pollToSave.responses);
+    const allowMultipleResponses = pollToSave.allowMultipleResponses ? 1 : 0;
+    const blind = pollToSave.blind ? 1 : 0;
+    const allowTextResponses = pollToSave.allowTextResponses ? 1 : 0;
+    const autoEndTimer = pollToSave.autoEndTimer;
+    const autoEndThreshold = pollToSave.autoEndThreshold;
+    const blindUntilEnded = pollToSave.blindUntilEnded ? 1 : 0;
 
     return dbRun(
         "INSERT INTO poll_history(class, prompt, responses, allowMultipleResponses, blind, allowTextResponses, createdAt, auto_end_timer, auto_end_threshold, blind_until_ended) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -534,8 +543,14 @@ async function clearPoll(classId, userSession, updateClass = true) {
     const classroom = classStateStore.getClassroom(classId);
     deleteWatchedPoll(classId);
 
-    const currentPollId = pollRuntimeStore.getLastSavedPollId(classId);
-    const savedPollResponses = classroom.poll.responses;
+    const pollSnapshot = structuredClone(classroom.poll);
+    let currentPollId = pollRuntimeStore.getLastSavedPollId(classId);
+    const savedPollResponses = pollSnapshot.responses;
+
+    // If this poll was never ended, create a history row now so clear-without-end still archives.
+    if (!currentPollId) {
+        currentPollId = await savePollToHistory(classId, pollSnapshot);
+    }
 
     classroom.poll.responses = [];
     classroom.poll.prompt = "";
@@ -553,21 +568,9 @@ async function clearPoll(classId, userSession, updateClass = true) {
         excludedRespondents: [],
     };
 
-    // If there is no current poll ID, clear the poll and return
-    if (!currentPollId) {
-        if (updateClass && userSession) {
-            emitClassUpdate(classId, userSession);
-        }
-        pollRuntimeStore.clearPogMeterTracker(classId);
-        pollRuntimeStore.clearLastSavedPollId(classId);
-        pollRuntimeStore.clearPollStartTime(classId);
-        return;
+    if (currentPollId) {
+        await savePollAnswersToHistory(classroom, currentPollId, classId, savedPollResponses);
     }
-
-    // Save poll to history
-    await savePollAnswersToHistory(classroom, currentPollId, classId, savedPollResponses);
-    await savePollToHistory(classId);
-    pollRuntimeStore.setLastSavedPollId(classId, currentPollId);
 
     if (updateClass && userSession) {
         emitClassUpdate(classId, userSession);

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -170,6 +170,7 @@ async function createPoll(classId, pollData, userData) {
         allowMultipleResponses,
         autoEndTimer,
         autoEndThreshold,
+        blindUntilEnded,
     } = pollData;
     const numberOfResponses = Object.keys(answers).length;
 
@@ -285,6 +286,11 @@ async function updatePoll(classId, options, userSession) {
 
         // Save to history when ending poll
         if (option === "status" && value === false && classroom.poll.status === true) {
+            // If the poll is set to blind until ended, then unblind the poll
+            if (classroom.poll.blindUntilEnded) {
+                classroom.poll.blind = false;
+            }
+
             const savedPollId = await savePollToHistory(classId);
             pollRuntimeStore.setLastSavedPollId(classId, savedPollId);
         }

--- a/services/tests/poll-service.spec.js
+++ b/services/tests/poll-service.spec.js
@@ -58,7 +58,15 @@ jest.mock("@stores/poll-runtime-store", () => ({
     },
 }));
 
-const { getPollResponses, deleteCustomPolls, getPreviousPolls, getCurrentPoll } = require("@services/poll-service");
+const {
+    createPoll,
+    updatePoll,
+    sendPollResponse,
+    getPollResponses,
+    deleteCustomPolls,
+    getPreviousPolls,
+    getCurrentPoll,
+} = require("@services/poll-service");
 const { classStateStore } = require("@services/classroom-service");
 const NotFoundError = require("@errors/not-found-error");
 const ForbiddenError = require("@errors/forbidden-error");
@@ -77,6 +85,9 @@ async function migratePollHistoryTable(db) {
                 "blind"                    INTEGER NOT NULL DEFAULT 0,
                 "allowTextResponses"       INTEGER NOT NULL DEFAULT 0,
                 "createdAt"                INTEGER NOT NULL,
+                "auto_end_timer"           INTEGER,
+                "auto_end_threshold"       INTEGER,
+                "blind_until_ended"        INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY ("id" AUTOINCREMENT)
             );
             `,
@@ -112,6 +123,167 @@ function makeClassData({ pollStatus = true, responses = [], students = {} } = {}
 function makeStudent(buttonRes = "", textRes = "") {
     return { pollRes: { buttonRes, textRes } };
 }
+
+describe("poll auto-end options", () => {
+    const teacherSession = { email: "teacher@test.com", id: 1 };
+    const basePollData = {
+        prompt: "Question?",
+        answers: [{ answer: "A" }, { answer: "B" }],
+        blind: false,
+        weight: 1,
+        excludedRespondents: [],
+        allowVoteChanges: true,
+        allowTextResponses: false,
+        allowMultipleResponses: false,
+    };
+
+    function setupActiveClassroom(overrides = {}) {
+        mockClassrooms[1] = {
+            isActive: true,
+            timer: { active: false, endTime: 0 },
+            poll: {
+                status: false,
+                prompt: "",
+                responses: [],
+                allowTextResponses: false,
+                allowMultipleResponses: false,
+                blind: false,
+                blindUntilEnded: false,
+                weight: 1,
+                excludedRespondents: [],
+            },
+            students: {
+                "student1@test.com": { id: 10, email: "student1@test.com", pollRes: { buttonRes: "", textRes: "" }, isOffline: false },
+                "student2@test.com": { id: 11, email: "student2@test.com", pollRes: { buttonRes: "", textRes: "" }, isOffline: false },
+            },
+            ...overrides,
+        };
+        return mockClassrooms[1];
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers({ now: 1_000_000 });
+        const { pollRuntimeStore } = require("@stores/poll-runtime-store");
+        pollRuntimeStore.hasPogMeterIncreased.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    it("defaults blind polls to blind-until-ended and unblinds them when ended", async () => {
+        const classroom = setupActiveClassroom();
+
+        await createPoll(1, { ...basePollData, blind: true }, teacherSession);
+
+        expect(classroom.poll.blind).toBe(true);
+        expect(classroom.poll.blindUntilEnded).toBe(true);
+
+        await updatePoll(1, { status: false }, teacherSession);
+
+        expect(classroom.poll.status).toBe(false);
+        expect(classroom.poll.blind).toBe(false);
+    });
+
+    it("auto-ends after the configured timer and leaves the ended poll visible", async () => {
+        const classroom = setupActiveClassroom();
+
+        await createPoll(1, { ...basePollData, autoEndTimer: 1000 }, teacherSession);
+
+        expect(classroom.poll.status).toBe(true);
+        expect(classroom.poll.endTime).toBe(1_001_000);
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(classroom.poll.status).toBe(false);
+        expect(classroom.poll.prompt).toBe("Question?");
+        expect(classroom.poll.responses).toHaveLength(2);
+    });
+
+    it("ignores non-number auto-end timer values instead of coercing them to milliseconds", async () => {
+        const classroom = setupActiveClassroom();
+
+        await createPoll(1, { ...basePollData, autoEndTimer: true }, teacherSession);
+
+        expect(classroom.poll.status).toBe(true);
+        expect(classroom.poll.autoEndTimer).toBeNull();
+        expect(classroom.poll.endTime).toBeNull();
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(classroom.poll.status).toBe(true);
+    });
+
+    it("ignores numeric string auto-end timer values instead of coercing them", async () => {
+        const classroom = setupActiveClassroom();
+
+        await createPoll(1, { ...basePollData, autoEndTimer: "1000" }, teacherSession);
+
+        expect(classroom.poll.status).toBe(true);
+        expect(classroom.poll.autoEndTimer).toBeNull();
+        expect(classroom.poll.endTime).toBeNull();
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(classroom.poll.status).toBe(true);
+    });
+
+    it("caps the auto-end countdown to the remaining active class timer", async () => {
+        const classroom = setupActiveClassroom({
+            timer: { active: true, endTime: 1_000_500 },
+        });
+
+        await createPoll(1, { ...basePollData, autoEndTimer: 1000 }, teacherSession);
+
+        expect(classroom.poll.endTime).toBe(1_000_500);
+
+        await jest.advanceTimersByTimeAsync(499);
+        expect(classroom.poll.status).toBe(true);
+
+        await jest.advanceTimersByTimeAsync(1);
+        expect(classroom.poll.status).toBe(false);
+    });
+
+    it("starts the auto-end countdown only after the response threshold is met", async () => {
+        const classroom = setupActiveClassroom();
+
+        await createPoll(1, { ...basePollData, autoEndTimer: 1000, autoEndThreshold: 50 }, teacherSession);
+
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(classroom.poll.status).toBe(true);
+        expect(classroom.poll.endTime).toBeNull();
+
+        await sendPollResponse(1, "A", "", { email: "student1@test.com", id: 10 });
+
+        expect(classroom.poll.endTime).toBe(1_002_000);
+
+        await jest.advanceTimersByTimeAsync(999);
+        expect(classroom.poll.status).toBe(true);
+
+        await jest.advanceTimersByTimeAsync(1);
+        expect(classroom.poll.status).toBe(false);
+    });
+
+    it("does not count stale responses from the previous poll toward the threshold", async () => {
+        const classroom = setupActiveClassroom({
+            students: {
+                "student1@test.com": { id: 10, email: "student1@test.com", pollRes: { buttonRes: "A", textRes: "" }, isOffline: false },
+                "student2@test.com": { id: 11, email: "student2@test.com", pollRes: { buttonRes: "B", textRes: "" }, isOffline: false },
+            },
+        });
+
+        await createPoll(1, { ...basePollData, autoEndTimer: 1000, autoEndThreshold: 80 }, teacherSession);
+
+        expect(classroom.students["student1@test.com"].pollRes.buttonRes).toBe("");
+        expect(classroom.students["student2@test.com"].pollRes.buttonRes).toBe("");
+        expect(classroom.poll.endTime).toBeNull();
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(classroom.poll.status).toBe(true);
+    });
+});
 
 describe("getPollResponses", () => {
     it("returns empty object when poll.status is false", () => {

--- a/sockets/polls/poll-creation.js
+++ b/sockets/polls/poll-creation.js
@@ -27,6 +27,9 @@ module.exports = {
                         lastResponse,
                         multiRes,
                         allowVoteChanges,
+                        autoEndTimer,
+                        autoEndThreshold,
+                        blindUntilEnded,
                     ] = args;
                     pollData = {
                         prompt: pollPrompt,
@@ -38,30 +41,30 @@ module.exports = {
                         weight: Number(weight ?? 1),
                         indeterminate: Array.isArray(indeterminate) ? indeterminate : [],
                         excludedRespondents: Array.isArray(boxes) ? boxes : [],
-                        autoEndTimer: Number(time),
-                        autoEndThreshold: autoEndThreshold,
-                        blindUntilEnded: !!blindUntilEnded,
                     };
+
+                    if (autoEndTimer !== undefined) pollData.autoEndTimer = autoEndTimer;
+                    if (autoEndThreshold !== undefined) pollData.autoEndThreshold = autoEndThreshold;
+                    if (blindUntilEnded !== undefined) pollData.blindUntilEnded = !!blindUntilEnded;
                 }
 
-                await createPoll(
-                    classId,
-                    {
-                        prompt: pollData.prompt,
-                        answers: Array.isArray(pollData.answers) ? pollData.answers : [],
-                        blind: !!pollData.blind,
-                        allowVoteChanges: !!pollData.allowVoteChanges,
-                        allowTextResponses: !!pollData.allowTextResponses,
-                        allowMultipleResponses: !!pollData.allowMultipleResponses,
-                        weight: Number(pollData.weight ?? 1),
-                        excludedRespondents: Array.isArray(pollData.excludedRespondents) ? pollData.excludedRespondents : [],
-                        indeterminate: Array.isArray(pollData.indeterminate) ? pollData.indeterminate : [],
-                        autoEndTimer: pollData.autoEndTimer,
-                        autoEndThreshold: pollData.autoEndThreshold,
-                        blindUntilEnded: pollData.blindUntilEnded,
-                    },
-                    socketContext.session
-                );
+                const normalizedPollData = {
+                    prompt: pollData.prompt,
+                    answers: Array.isArray(pollData.answers) ? pollData.answers : [],
+                    blind: !!pollData.blind,
+                    allowVoteChanges: !!pollData.allowVoteChanges,
+                    allowTextResponses: !!pollData.allowTextResponses,
+                    allowMultipleResponses: !!pollData.allowMultipleResponses,
+                    weight: Number(pollData.weight ?? 1),
+                    excludedRespondents: Array.isArray(pollData.excludedRespondents) ? pollData.excludedRespondents : [],
+                    indeterminate: Array.isArray(pollData.indeterminate) ? pollData.indeterminate : [],
+                };
+
+                if (pollData.autoEndTimer !== undefined) normalizedPollData.autoEndTimer = pollData.autoEndTimer;
+                if (pollData.autoEndThreshold !== undefined) normalizedPollData.autoEndThreshold = pollData.autoEndThreshold;
+                if (pollData.blindUntilEnded !== undefined) normalizedPollData.blindUntilEnded = pollData.blindUntilEnded;
+
+                await createPoll(classId, normalizedPollData, socketContext.session);
                 socket.emit("startPoll");
             } catch (err) {
                 handleSocketError(err, socket, "startPoll");

--- a/sockets/polls/poll-creation.js
+++ b/sockets/polls/poll-creation.js
@@ -40,6 +40,7 @@ module.exports = {
                         excludedRespondents: Array.isArray(boxes) ? boxes : [],
                         autoEndTimer: Number(time),
                         autoEndThreshold: autoEndThreshold,
+                        blindUntilEnded: !!blindUntilEnded,
                     };
                 }
 
@@ -57,6 +58,7 @@ module.exports = {
                         indeterminate: Array.isArray(pollData.indeterminate) ? pollData.indeterminate : [],
                         autoEndTimer: pollData.autoEndTimer,
                         autoEndThreshold: pollData.autoEndThreshold,
+                        blindUntilEnded: pollData.blindUntilEnded,
                     },
                     socketContext.session
                 );

--- a/sockets/polls/poll-creation.js
+++ b/sockets/polls/poll-creation.js
@@ -1,4 +1,3 @@
-const { classStateStore } = require("@services/classroom-service");
 const { createPoll } = require("@services/poll-service");
 const { handleSocketError } = require("@modules/socket-error-handler");
 const { SCOPES } = require("@modules/permissions");
@@ -39,6 +38,8 @@ module.exports = {
                         weight: Number(weight ?? 1),
                         indeterminate: Array.isArray(indeterminate) ? indeterminate : [],
                         excludedRespondents: Array.isArray(boxes) ? boxes : [],
+                        autoEndTimer: Number(time),
+                        autoEndThreshold: autoEndThreshold,
                     };
                 }
 
@@ -54,6 +55,8 @@ module.exports = {
                         weight: Number(pollData.weight ?? 1),
                         excludedRespondents: Array.isArray(pollData.excludedRespondents) ? pollData.excludedRespondents : [],
                         indeterminate: Array.isArray(pollData.indeterminate) ? pollData.indeterminate : [],
+                        autoEndTimer: pollData.autoEndTimer,
+                        autoEndThreshold: pollData.autoEndThreshold,
                     },
                     socketContext.session
                 );

--- a/sockets/tests/poll-creation.spec.js
+++ b/sockets/tests/poll-creation.spec.js
@@ -72,6 +72,43 @@ describe("startPoll", () => {
         );
     });
 
+    it("should pass auto-end options from the legacy payload to createPoll", async () => {
+        await startPollHandler(false, true, "Prompt", [{ answer: "A" }], true, 2, [7], ["ghost"], null, true, false, 5000, 80, true);
+
+        expect(createPoll).toHaveBeenCalledWith(
+            testData.classId,
+            {
+                prompt: "Prompt",
+                answers: [{ answer: "A" }],
+                blind: true,
+                allowVoteChanges: false,
+                weight: 2,
+                excludedRespondents: [7],
+                indeterminate: ["ghost"],
+                allowTextResponses: true,
+                allowMultipleResponses: true,
+                autoEndTimer: 5000,
+                autoEndThreshold: 80,
+                blindUntilEnded: true,
+            },
+            socket.request.session
+        );
+    });
+
+    it("should not coerce boolean auto-end timer values to milliseconds", async () => {
+        await startPollHandler(false, true, "Prompt", [{ answer: "A" }], true, 2, [7], ["ghost"], null, true, false, true, 80, true);
+
+        expect(createPoll).toHaveBeenCalledWith(
+            testData.classId,
+            expect.objectContaining({
+                autoEndTimer: true,
+                autoEndThreshold: 80,
+                blindUntilEnded: true,
+            }),
+            socket.request.session
+        );
+    });
+
     it("should route poll creation errors through handleSocketError", async () => {
         createPoll.mockRejectedValueOnce(new Error("Test Error"));
 


### PR DESCRIPTION
`npm run migrate` is required for this change.
This PR solves issues #773 and #1025 by adding additional poll options. These poll options are described below.

Auto-End Timer - Determines a countdown to end the poll. 
Auto-End Threshold - Determines a percentage of students who have to respond before Auto-End Timer is initiated. If null, it will have no effect and only Auto-End Timer will be used. 
Blind until Ended (default true) - Determines if the poll results should be visible to everyone once a blind poll is ended