### PR TITLE
Poll history responses

### DIFF
--- a/api/v1/controllers/class/polls/polls.js
+++ b/api/v1/controllers/class/polls/polls.js
@@ -24,9 +24,9 @@ module.exports = (router) => {
      *     tags:
      *       - Class - Polls
      *     description: |
-     *       Returns the poll history data for a class, including responses. Results are paginated.
-     *
-     *       **Required Permission:** Must be a member of the class (Class-specific `seePoll` permission, default: Guest)
+     *       Returns the poll history data for a class, excluding responses. Results are paginated.
+     *     
+	 *       **Required Permission:** `CLASS.POLL.READ`
      *
      *       **Permission Levels:**
      *       - 1: Guest
@@ -146,6 +146,169 @@ module.exports = (router) => {
      */
     router.get(
         "/class/:id/polls",
+        isAuthenticated,
+        isOwnerOrHasScopes(membershipService.classroomOwnerCheck, SCOPES.CLASS.POLL.READ, "You do not have permission to view polls for this class."),
+        async (req, res) => {
+            const classId = req.params.id;
+            requireQueryParam(classId, "classId");
+
+            // Ensure the authenticated user is logged into / associated with this class.
+            const userClassId = req.user?.classId ?? req.user?.activeClass ?? classStateStore.getUser(req.user?.email)?.activeClass;
+            if (!userClassId || String(userClassId) !== String(classId)) {
+                return res.status(403).json({
+                    success: false,
+                    error: "User is not logged into the selected class or lacks permission",
+                });
+            }
+
+            req.infoEvent("class.polls.view", "Viewing class polls", { classId });
+
+            const { limit, offset } = parsePaginationQuery(req.query, DEFAULT_POLL_LIMIT, MAX_POLL_LIMIT);
+
+            const { polls, total } = await getPreviousPolls(classId, limit, offset);
+
+            req.infoEvent("class.polls.data_sent", "Poll data sent to client", { classId, pollCount: polls.length, limit, offset });
+
+            res.status(200).json({
+                success: true,
+                data: {
+                    polls,
+                    pagination: buildPagination(total, limit, offset, polls.length),
+                },
+            });
+        }
+    );
+
+	/**
+     * @swagger
+     * /api/v1/class/{id}/pollhistory:
+     *   get:
+     *     summary: Get history of polls in a class
+     *     tags:
+     *       - Class - Polls
+     *     description: |
+     *       Returns the poll history data for a class, including responses. Results are paginated.
+     *
+     *       **Required Permission:** `CLASS.POLL.READ`
+     *
+     *       **Permission Levels:**
+     *       - 1: Guest
+     *       - 2: Student
+     *       - 3: Moderator
+     *       - 4: Teacher
+     *       - 5: Manager
+     *     security:
+     *       - bearerAuth: []
+     *       - apiKeyAuth: []
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         required: true
+     *         schema:
+     *           type: string
+     *         description: Class ID
+     *       - in: query
+     *         name: limit
+     *         required: false
+     *         schema:
+     *           type: integer
+     *           default: 20
+     *           minimum: 1
+     *           maximum: 100
+     *         description: Maximum number of polls to return
+     *       - in: query
+     *         name: offset
+     *         required: false
+     *         schema:
+     *           type: integer
+     *           default: 0
+     *           minimum: 0
+     *         description: Number of polls to skip before returning results
+     *     responses:
+     *       200:
+     *         description: Poll data retrieved successfully
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 success:
+     *                   type: boolean
+     *                   example: true
+     *                 data:
+     *                   type: object
+     *                   properties:
+     *                     polls:
+     *                       type: array
+     *                       items:
+     *                         type: object
+     *                         properties:
+     *                           pollId:
+     *                             type: integer
+     *                             description: Class-relative poll ID (increments within a class)
+     *                             example: 12
+     *                           prompt:
+     *                             type: string
+     *                             description: Poll prompt shown to students
+     *                             example: True/False
+     *                           responses:
+     *                             type: array
+     *                             description: Poll options and aggregate response counts
+     *                             items:
+     *                               type: object
+     *                               properties:
+     *                                 answer:
+     *                                   type: string
+     *                                   example: True
+     *                                 weight:
+     *                                   type: number
+     *                                   example: 1
+     *                                 color:
+     *                                   type: string
+     *                                   example: '#00ff00'
+     *                                 responses:
+     *                                   type: integer
+     *                                   example: 8
+     *                           allowMultipleResponses:
+     *                             type: boolean
+     *                             example: false
+     *                           blind:
+     *                             type: boolean
+     *                             example: false
+     *                           allowTextResponses:
+     *                             type: boolean
+     *                             example: false
+     *                           createdAt:
+     *                             type: integer
+     *                             description: Poll creation timestamp in milliseconds
+     *                             example: 1712428800000
+     *       400:
+     *         description: Invalid parameters
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/ValidationError'
+     *       401:
+     *         description: Not authenticated
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/UnauthorizedError'
+     *       403:
+     *         description: User is not logged into the selected class or lacks permission
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/Error'
+     *       404:
+     *         description: Class not found
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/NotFoundError'
+     */
+    router.get(
+        "/class/:id/pollhistory",
         isAuthenticated,
         isOwnerOrHasScopes(membershipService.classroomOwnerCheck, SCOPES.CLASS.POLL.READ, "You do not have permission to view polls for this class."),
         async (req, res) => {

--- a/api/v1/controllers/class/polls/polls.js
+++ b/api/v1/controllers/class/polls/polls.js
@@ -298,7 +298,7 @@ module.exports = (router) => {
     router.get(
         "/class/:id/pollhistory",
         isAuthenticated,
-        isOwnerOrHasScopes(SCOPES.CLASS.SYSTEM.ADMIN, "You do not have permission to view polls with user responses for this class."),
+        isOwnerOrHasScopes(membershipService.classroomOwnerCheck, SCOPES.CLASS.SYSTEM.ADMIN, "You do not have permission to view polls with user responses for this class."),
         async (req, res) => {
             const classId = req.params.id;
             requireQueryParam(classId, "classId");

--- a/api/v1/controllers/class/polls/polls.js
+++ b/api/v1/controllers/class/polls/polls.js
@@ -2,7 +2,7 @@ const { requireQueryParam } = require("@modules/error-wrapper");
 const { getPreviousPolls } = require("@services/poll-service");
 const { classStateStore } = require("@services/classroom-service");
 const { isAuthenticated } = require("@middleware/authentication");
-const { isOwnerOrHasScopes } = require("@middleware/permission-check");
+const { hasClassScope, isOwnerOrHasScopes } = require("@middleware/permission-check");
 const { SCOPES } = require("@modules/permissions");
 const { buildPagination, parsePaginationQuery } = require("@modules/pagination");
 const membershipService = require("@services/class-membership-service");
@@ -28,12 +28,6 @@ module.exports = (router) => {
      *     
 	 *       **Required Permission:** `CLASS.POLL.READ`
      *
-     *       **Permission Levels:**
-     *       - 1: Guest
-     *       - 2: Student
-     *       - 3: Moderator
-     *       - 4: Teacher
-     *       - 5: Manager
      *     security:
      *       - bearerAuth: []
      *       - apiKeyAuth: []
@@ -189,14 +183,8 @@ module.exports = (router) => {
      *     description: |
      *       Returns the poll history data for a class, including responses. Results are paginated.
      *
-     *       **Required Permission:** `CLASS.POLL.READ`
+     *       **Required Permission:** `CLASS.SYSTEM.ADMIN`
      *
-     *       **Permission Levels:**
-     *       - 1: Guest
-     *       - 2: Student
-     *       - 3: Moderator
-     *       - 4: Teacher
-     *       - 5: Manager
      *     security:
      *       - bearerAuth: []
      *       - apiKeyAuth: []
@@ -310,7 +298,7 @@ module.exports = (router) => {
     router.get(
         "/class/:id/pollhistory",
         isAuthenticated,
-        isOwnerOrHasScopes(membershipService.classroomOwnerCheck, SCOPES.CLASS.POLL.READ, "You do not have permission to view polls for this class."),
+        hasClassScope(SCOPES.CLASS.SYSTEM.ADMIN, "You do not have permission to view polls with user responses for this class."),
         async (req, res) => {
             const classId = req.params.id;
             requireQueryParam(classId, "classId");
@@ -328,7 +316,7 @@ module.exports = (router) => {
 
             const { limit, offset } = parsePaginationQuery(req.query, DEFAULT_POLL_LIMIT, MAX_POLL_LIMIT);
 
-            const { polls, total } = await getPreviousPolls(classId, limit, offset);
+            const { polls, total } = await getPreviousPolls(classId, limit, offset, true);
 
             req.infoEvent("class.polls.data_sent", "Poll data sent to client", { classId, pollCount: polls.length, limit, offset });
 

--- a/api/v1/controllers/class/polls/polls.js
+++ b/api/v1/controllers/class/polls/polls.js
@@ -298,7 +298,7 @@ module.exports = (router) => {
     router.get(
         "/class/:id/pollhistory",
         isAuthenticated,
-        hasClassScope(SCOPES.CLASS.SYSTEM.ADMIN, "You do not have permission to view polls with user responses for this class."),
+        isOwnerOrHasScopes(SCOPES.CLASS.SYSTEM.ADMIN, "You do not have permission to view polls with user responses for this class."),
         async (req, res) => {
             const classId = req.params.id;
             requireQueryParam(classId, "classId");

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -452,7 +452,7 @@ async function getPreviousPolls(classId, limit = 20, offset = 0, includeResponse
         [classId, limit, offset]
     );
 
-    const enrichedPolls = polls.map((poll) => {
+    const enrichedPolls = await Promise.all(polls.map(async (poll) => {
         // Parse responses into a predictable array for clients.
         let parsedResponses = poll.responses;
         if (typeof poll.responses === "string") {
@@ -467,7 +467,24 @@ async function getPreviousPolls(classId, limit = 20, offset = 0, includeResponse
             parsedResponses = [];
         }
 
-		console.log(parsedResponses)
+
+		if(includeResponses) {
+			parsedResponses.forEach((resp) => { resp.studentsResponded = [] });
+
+			const userResponses = await dbGetAll("SELECT * FROM poll_answers WHERE classId = ? AND pollId = ?", [classId, poll.id]);
+
+			userResponses.map((studentRes) => {
+				const studentResponseIds = JSON.parse(studentRes.responseIds);
+				const matchingResponses = parsedResponses.filter((response) => studentResponseIds.includes(response.id));
+				matchingResponses.forEach((matchedResp) => matchedResp.studentsResponded.push(
+					{
+						userId: studentRes.userId,
+						textResponse: studentRes.textResponse,
+						respondedAt: studentRes.createdAt
+					}
+				));
+			})
+		}
 
         return {
             globalPollId: poll.id,
@@ -479,7 +496,7 @@ async function getPreviousPolls(classId, limit = 20, offset = 0, includeResponse
             allowTextResponses: !!poll.allowTextResponses,
             createdAt: poll.createdAt,
         };
-    });
+    }));
 
     return {
         polls: enrichedPolls,

--- a/services/poll-service.js
+++ b/services/poll-service.js
@@ -436,9 +436,10 @@ async function updatePoll(classId, options, userSession) {
  * @param {number} classId - The ID of the class.
  * @param {number} [limit=20] - The maximum number of records to return.
  * @param {number} [offset=0] - The number of records to skip.
+ * @param {boolean} [includeResponses=false] - Include user responses in the returned data?\
  * @returns {Promise<Object>} An object containing polls array and total count.
  */
-async function getPreviousPolls(classId, limit = 20, offset = 0) {
+async function getPreviousPolls(classId, limit = 20, offset = 0, includeResponses = false) {
     requireInternalParam(classId, "classId");
 
     const totalRow = await dbGet(`SELECT COUNT(*) AS count FROM poll_history WHERE class = ?`, [classId]);
@@ -465,6 +466,8 @@ async function getPreviousPolls(classId, limit = 20, offset = 0) {
         if (!Array.isArray(parsedResponses)) {
             parsedResponses = [];
         }
+
+		console.log(parsedResponses)
 
         return {
             globalPollId: poll.id,


### PR DESCRIPTION
Adds a `/pollhistory` endpoint that includes user responses, along with their response time and response text (if applicable)